### PR TITLE
Enhance run_analysis to return detailed action metrics and baseline rho

### DIFF
--- a/expert_op4grid_recommender/pypowsybl_backend/observation.py
+++ b/expert_op4grid_recommender/pypowsybl_backend/observation.py
@@ -19,21 +19,23 @@ if TYPE_CHECKING:
 class PypowsyblObservation:
     """
     Grid2op-compatible observation interface for pypowsybl networks.
-    
+
     Provides read-only access to network state including:
     - Line flows and loading ratios (rho)
     - Line status (connected/disconnected)
     - Bus voltage magnitudes and angles
     - Load and generation values
     - Topology information
-    
+
     The simulate() method creates a temporary variant, applies an action,
     runs load flow, extracts results, and cleans up the variant.
-    
+
     Attributes:
         _network_manager: Reference to the NetworkManager
         _thermal_limits: Cached thermal limits for rho calculation
     """
+
+    _kept_variant_counter = 0
     
     def __init__(self, 
                  network_manager: 'NetworkManager',
@@ -717,7 +719,11 @@ class PypowsyblObservation:
             - info: Dictionary with 'exception' key if errors occurred
         """
         nm = self._network_manager
-        variant_id = f"simulate_{id(action)}_{time_step}"
+        if keep_variant:
+            PypowsyblObservation._kept_variant_counter += 1
+            variant_id = f"simulate_kept_{PypowsyblObservation._kept_variant_counter}_{time_step}"
+        else:
+            variant_id = f"simulate_{id(action)}_{time_step}"
         info = {"exception": []}
 
         try:


### PR DESCRIPTION
## Summary
This PR refactors the `run_analysis` function to return comprehensive action details including rho evolution metrics, baseline rho values, and observation objects. It also adds support for both Grid2Op and pypowsybl backends with proper variant lifecycle management.

## Key Changes

- **Enhanced return structure**: `run_analysis` now returns a dictionary with `lines_overloaded_names` and `prioritized_actions` containing detailed metrics for each action:
  - `action`: The action object
  - `description_unitaire`: Action description from action file
  - `rho_before`: Baseline rho on overloaded lines
  - `rho_after`: Rho after action on overloaded lines
  - `max_rho`: Maximum rho across monitored lines
  - `max_rho_line`: Name of line with maximum rho
  - `is_rho_reduction`: Whether action reduces all overloads
  - `observation`: Observation after action simulation

- **Baseline rho computation**: Added `compute_baseline_simulation_grid2op` and `compute_baseline_simulation_pypowsybl` wrapper functions that compute baseline rho once and reuse it for all actions, improving efficiency

- **Backend abstraction**: Integrated baseline computation into backend selection logic, allowing both Grid2Op and pypowsybl backends to provide baseline metrics

- **pypowsybl variant management**: Enhanced `PypowsyblObservation.simulate()` with `keep_variant` parameter to optionally preserve network variants after simulation, storing the variant ID as `_variant_id` on the observation object. The caller is responsible for cleanup.

- **Improved error handling**: Empty overload case now returns proper structure with empty actions dict instead of empty dict

- **Test updates**: Updated all test cases to verify the new return structure and detailed action information, including pypowsybl-specific variant ID validation

## Implementation Details

- Baseline rho is computed once per reassessment phase and reused for all actions to avoid redundant simulations
- Rho reduction is determined by checking if all overloaded lines have rho reduced by at least 0.01 after the action
- Max rho calculation respects `lines_we_care_about` filtering when available
- pypowsybl observations can now maintain variant references for post-analysis inspection
- Code formatting improvements (trailing whitespace cleanup)

https://claude.ai/code/session_01HTiLuszQE2MtmqVb8NQshM