### PR TITLE
Make grid2op imports optional with graceful fallback

### DIFF
--- a/expert_op4grid_recommender/utils/data_utils.py
+++ b/expert_op4grid_recommender/utils/data_utils.py
@@ -1,9 +1,14 @@
 import copy
 from datetime import datetime
-from typing import Dict
-from grid2op.Environment import Environment
-from grid2op.Observation import BaseObservation
-from grid2op.typing_variables import RESET_OPTIONS_TYPING
+from typing import Any, Dict
+
+try:
+    from grid2op.Environment import Environment
+    from grid2op.Observation import BaseObservation
+    from grid2op.typing_variables import RESET_OPTIONS_TYPING
+    _HAS_GRID2OP = True
+except (ImportError, Exception):
+    _HAS_GRID2OP = False
 
 
 class StateInfo:
@@ -20,15 +25,15 @@ class StateInfo:
         self.init_line_or_id = None
         #: the extremity bus id to which the n-1 was before being disconnectd
         self.init_line_ex_id = None
-        #: the name of each line that cannot be reconnected 
+        #: the name of each line that cannot be reconnected
         self.should_not_reco = None
         #: the state used to initialize the environment to the proper state
-        self.init_state : RESET_OPTIONS_TYPING = None
+        self.init_state = None
         #: backend type
         self.backend_type = None
-        
+
     @classmethod
-    def from_init_state(cls, env: Environment, init_state: Dict, del_attr=None):
+    def from_init_state(cls, env: Any, init_state: Dict, del_attr=None):
         res = cls()
         res.obs_datetime = init_state["datetime"]
         if "n1_name" in init_state:
@@ -53,13 +58,13 @@ class StateInfo:
             res.should_not_reco = set(copy.deepcopy(init_state["should_not_reco"]))
         else:
             # I suppose that if a line was disconnected then it should not be reconnected
-            res.should_not_reco = set([nm for nm, stat_ in init_state["init state"]["set_line_status"].items() 
+            res.should_not_reco = set([nm for nm, stat_ in init_state["init state"]["set_line_status"].items()
                                    if int(stat_) == -1])
         if not res.n1_name in res.should_not_reco:
             res.should_not_reco.add(res.n1_name)
         if "backend_type" in init_state:
-            res.backend_type = str(init_state["backend_type"])  
-            
+            res.backend_type = str(init_state["backend_type"])
+
         if del_attr is None:
             # all attributes are deleted from init_state
             del init_state["datetime"]
@@ -83,8 +88,8 @@ class StateInfo:
         res.init_state = init_state
         res.init_state["init datetime"] = datetime.strptime(res.obs_datetime, "%Y%m%d-%H%M")
         return res
-    
-    def set_env_state(self, env : Environment) -> BaseObservation:
+
+    def set_env_state(self, env: Any) -> Any:
         """
         .. danger::
             Do not use asynchronously `state.set_env_state(env)` for different states with the same


### PR DESCRIPTION
## Summary
This PR refactors the codebase to make grid2op a soft dependency rather than a hard requirement. Grid2op imports are now wrapped in try-except blocks with a feature flag (`_HAS_GRID2OP`), allowing the module to be imported even when grid2op is not installed. Functions that require grid2op will raise an informative error at runtime if called without the dependency.

## Key Changes

- **Conditional grid2op imports**: Wrapped all grid2op imports in try-except blocks in `load_training_data.py` and `data_utils.py` with a `_HAS_GRID2OP` flag to detect availability
- **Type annotation updates**: Changed grid2op-specific type hints (`Environment`, `BaseObservation`, `BaseAction`) to `Any` in function signatures to avoid import errors when grid2op is unavailable
- **Lazy imports**: Moved `tqdm` and `pandas` imports to function scope in `load_training_data.py` since they're only used in specific functions
- **Runtime validation**: Added explicit `_HAS_GRID2OP` check in `filter_out_non_reproductible_observation()` to raise a clear error if grid2op is needed but not available
- **Deferred imports in main block**: Moved `make_grid2op_training_env` import to the `if __name__ == "__main__"` block where it's actually used
- **Code cleanup**: Fixed minor formatting issues (trailing whitespace, spacing around colons)

## Implementation Details

The approach uses a feature flag pattern that allows:
1. The module to be imported without grid2op installed
2. Core utilities like `StateInfo` to remain functional
3. Grid2op-dependent functions to fail gracefully with clear error messages
4. Reduced import overhead for users who don't need grid2op functionality

https://claude.ai/code/session_014S6kkKrmtAXjHV7N6Jgv9Y