### PR TITLE
Make grid2op optional in make_env_utils and related modules

### DIFF
--- a/expert_op4grid_recommender/environment.py
+++ b/expert_op4grid_recommender/environment.py
@@ -13,13 +13,17 @@ import os
 import json
 import datetime
 import sys
-from expert_op4grid_recommender.utils.make_assistant_env import make_grid2op_assistant_env
-from expert_op4grid_recommender.utils.make_training_env import make_grid2op_training_env
-from expert_op4grid_recommender.utils.load_evaluation_data import list_all_chronics, get_first_obs_on_chronic
 from expert_op4grid_recommender import config
-# FIX: Import the config module relatively
 from expert_op4grid_recommender.data_loader import load_interesting_lines, DELETED_LINE_NAME, load_actions
 from expert_op4grid_recommender.utils.simulation import simulate_contingency, check_simu_overloads
+
+try:
+    from expert_op4grid_recommender.utils.make_assistant_env import make_grid2op_assistant_env
+    from expert_op4grid_recommender.utils.make_training_env import make_grid2op_training_env
+    from expert_op4grid_recommender.utils.load_evaluation_data import list_all_chronics, get_first_obs_on_chronic
+    _HAS_GRID2OP = True
+except (ImportError, Exception):
+    _HAS_GRID2OP = False
 
 
 
@@ -47,6 +51,8 @@ def get_env_first_obs(env_folder, env_name, use_evaluation_config, date=None, is
             - obs (grid2op.Observation): The first observation object for the selected chronic.
             - path_chronic (str): The file path to the selected chronic data.
     """
+    if not _HAS_GRID2OP:
+        raise ImportError("grid2op is required for get_env_first_obs()")
     if use_evaluation_config:
         env = make_grid2op_assistant_env(env_folder, env_name)
         if is_DC:

--- a/expert_op4grid_recommender/utils/load_evaluation_data.py
+++ b/expert_op4grid_recommender/utils/load_evaluation_data.py
@@ -6,9 +6,6 @@ import datetime
 from expert_op4grid_recommender.utils.data_utils import StateInfo
 import pandas as pd
 
-
-from expert_op4grid_recommender.utils.make_assistant_env import make_grid2op_assistant_env
-
 from expert_op4grid_recommender.utils.load_training_data import aux_prevent_asset_reconnection, load_interesting_lines
 
 #: name of the powerline that are now removed (non existant)
@@ -145,6 +142,8 @@ def run_remedial_action(obs,defaut,lines_non_reconnectable,env,id_interesting_li
     return overloaded_timesteps
     
 if __name__ == "__main__":
+    from expert_op4grid_recommender.utils.make_assistant_env import make_grid2op_assistant_env
+
     path_env = '.'
     nm_env = "env_dijon_v2_assistant"
     defaut = "AISERL31RONCI"  # "AISERL31RONCI"#"P.SAOL31RONCI"#line_we_disconnect[0]

--- a/expert_op4grid_recommender/utils/make_assistant_env.py
+++ b/expert_op4grid_recommender/utils/make_assistant_env.py
@@ -1,19 +1,25 @@
-from typing import Dict, Literal, Union
+from typing import Any, Dict, Literal, Union
 import os
-
-import grid2op
-from grid2op.Environment import Environment
-from grid2op.Backend import Backend
 import logging
-from pypowsybl2grid import PyPowSyBlBackend
 
 from expert_op4grid_recommender.utils.make_env_utils import (N_BUSBAR_PER_SUB,
                                                              make_default_params,
                                                              create_olf_rte_parameter)
-from grid2op.Chronics import ChangeNothing
+
+try:
+    import grid2op
+    from grid2op.Environment import Environment
+    from grid2op.Backend import Backend
+    from grid2op.Chronics import ChangeNothing
+    from pypowsybl2grid import PyPowSyBlBackend
+    _HAS_GRID2OP = True
+except (ImportError, Exception):
+    _HAS_GRID2OP = False
 
 def create_pypowsybl_backend(n_busbar_per_sub,
-                             check_isolated_and_disconnected_injections) -> Backend:
+                             check_isolated_and_disconnected_injections) -> Any:
+    if not _HAS_GRID2OP:
+        raise ImportError("grid2op and pypowsybl2grid are required for create_pypowsybl_backend()")
     logging.basicConfig()
     logging.getLogger().setLevel(logging.ERROR)
     logging.getLogger('powsybl').setLevel(logging.ERROR)
@@ -29,7 +35,7 @@ def make_grid2op_assistant_env(path_env,
                                 *,
                                 allow_detachment=True,
                                 params=None,
-                                n_busbar=N_BUSBAR_PER_SUB) -> Environment:
+                                n_busbar=N_BUSBAR_PER_SUB) -> Any:
     backend = create_pypowsybl_backend(n_busbar_per_sub=n_busbar,
                                        check_isolated_and_disconnected_injections=False)
     backend._prevent_automatic_disconnection = False

--- a/expert_op4grid_recommender/utils/make_training_env.py
+++ b/expert_op4grid_recommender/utils/make_training_env.py
@@ -1,16 +1,18 @@
-from typing import Dict, Literal, Union
+from typing import Any, Dict, Literal, Union
 import os
-
-import lightsim2grid
-from lightsim2grid import LightSimBackend
-
-import grid2op
-from grid2op.Environment import Environment
 
 from expert_op4grid_recommender.utils.make_env_utils import (make_backend_kwargs_data,
                                                              make_default_params)
 
-from grid2op.Chronics import ChangeNothing
+try:
+    import lightsim2grid
+    from lightsim2grid import LightSimBackend
+    import grid2op
+    from grid2op.Environment import Environment
+    from grid2op.Chronics import ChangeNothing
+    _HAS_GRID2OP = True
+except (ImportError, Exception):
+    _HAS_GRID2OP = False
 
     
 def make_grid2op_training_env(path_env: str,
@@ -19,7 +21,9 @@ def make_grid2op_training_env(path_env: str,
                               allow_detachment=True,
                               params=None,
                               backend_loader_kwargs=None,
-                              **bk_kwargs) -> Environment:
+                              **bk_kwargs) -> Any:
+    if not _HAS_GRID2OP:
+        raise ImportError("grid2op and lightsim2grid are required for make_grid2op_training_env()")
     backend_kwargs_data = make_backend_kwargs_data(loader_kwargs=backend_loader_kwargs, **bk_kwargs)
     backend = LightSimBackend(**backend_kwargs_data)
     path = os.path.join(path_env, nm_env)


### PR DESCRIPTION
Wrap grid2op/lightsim2grid imports in try/except in:
- make_env_utils.py: grid2op, lightsim2grid, pypowsybl2grid version checks
- make_assistant_env.py: grid2op, pypowsybl2grid imports
- make_training_env.py: grid2op, lightsim2grid imports
- environment.py: deferred grid2op-dependent imports
- load_evaluation_data.py: moved make_grid2op_assistant_env to __main__

Grid2op-only functions raise clear ImportError when called without grid2op.

https://claude.ai/code/session_014S6kkKrmtAXjHV7N6Jgv9Y