### PR TITLE
Claude/action scores dictionary iz7 lg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Line disconnection scoring**: asymmetric bell curve (alpha=3, beta=1.5) centred between the minimum required redispatch and the maximum tolerable redispatch; score is positive inside the acceptable window and negative outside.
 - **Node merging scoring**: delta-phase score (`theta2 − theta1`) based on voltage angle difference between the two buses being merged; the red-loop bus (carrying more positive dispatch flow) is used as the reference.
 - **Node splitting — per-action details**: `compute_node_splitting_action_score_value` now returns a `(score, details)` tuple. `details` contains `node_type`, `bus_of_interest`, and the four flow components (`in_negative_flows`, `out_negative_flows`, `in_positive_flows`, `out_positive_flows`) for the selected bus; these are stored per-action in `params_splits_dict` and exposed through `action_scores["open_coupling"]["params"]`.
+- **Per-action assets for coupling actions**: `action_scores["open_coupling"]["params"]` and `action_scores["close_coupling"]["params"]` now include per-action `"assets"` dictionaries listing the lines, loads, and generators connected to the scored bus.
+- **Unconstrained disconnection scoring**: when the overflow graph produces no new overloads after redispatch (i.e. `max_redispatch = ∞`), a linear ramp replaces the bell curve — score = 1 at `max_overload_flow`, linearly decreasing to 0 at `min_redispatch`, and negative quadratic tail below. The `params` field includes a `"regime"` indicator (`"constrained"` or `"unconstrained"`).
 - **Score rounding**: all float values in `action_scores` (both scores and params) are rounded to 2 decimal places.
 
 ### Fixed
@@ -30,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Backward compatibility tests: `compute_node_splitting_action_score` wraps a plain-float return as `(float, {})` and passes a tuple through unchanged.
 - `TestDiscoveryParamsStorage` (4 tests): verifies that `params_reconnections`, `params_disconnections`, `params_splits_dict`, and `params_merges` are correctly populated after each discovery method.
 - `TestActionScoresStructureAndRounding` (7 tests): verifies the assembled `action_scores` structure, descending sort order, 2-decimal rounding for flat and nested params, and graceful handling of empty categories.
+- `TestUnconstrainedLinearScore` (7 tests): verifies the linear ramp scoring for the unconstrained disconnection regime — score at min/max/midpoint, capping at 1 above max, zero at min, negative quadratic tail below min, and increasingly negative further below.
 
 ---
 

--- a/expert_op4grid_recommender/action_evaluation/discovery.py
+++ b/expert_op4grid_recommender/action_evaluation/discovery.py
@@ -1013,6 +1013,66 @@ class ActionDiscoverer:
 
         return action_topo_vect, is_single_node
 
+    def _get_assets_on_bus_for_sub(self, sub_id, bus, bus_assignments=None):
+        """Get asset names connected to a specific bus at a substation.
+
+        Uses the element ordering from ``get_obj_connect_to`` / ``sub_topology``
+        (loads, generators, lines_or, lines_ex) to match each element to its bus.
+
+        Args:
+            sub_id: Substation index.
+            bus: Target bus number (1 or 2).
+            bus_assignments: Optional array of bus assignments for all elements at
+                the substation (e.g. from an action's topology vector).
+                If *None*, the current observation's ``sub_topology`` is used.
+
+        Returns:
+            dict with keys ``"lines"``, ``"loads"``, ``"generators"``,
+            each containing a list of element name strings.
+        """
+        obs = self.obs_defaut
+        obj = obs.get_obj_connect_to(substation_id=sub_id)
+
+        if bus_assignments is None:
+            bus_assignments = obs.sub_topology(sub_id=sub_id)
+
+        # sub_topology order: loads, gens, lines_or, lines_ex
+        load_ids = obj.get('loads_id', [])
+        gen_ids = obj.get('generators_id', [])
+        line_or_ids = obj.get('lines_or_id', [])
+        line_ex_ids = obj.get('lines_ex_id', [])
+
+        assets = {"lines": [], "loads": [], "generators": []}
+        pos = 0
+
+        for load_idx in load_ids:
+            if pos < len(bus_assignments) and int(bus_assignments[pos]) == bus:
+                if hasattr(obs, 'name_load') and load_idx < len(obs.name_load):
+                    assets["loads"].append(str(obs.name_load[load_idx]))
+            pos += 1
+
+        for gen_idx in gen_ids:
+            if pos < len(bus_assignments) and int(bus_assignments[pos]) == bus:
+                if hasattr(obs, 'name_gen') and gen_idx < len(obs.name_gen):
+                    assets["generators"].append(str(obs.name_gen[gen_idx]))
+            pos += 1
+
+        for line_idx in line_or_ids:
+            if pos < len(bus_assignments) and int(bus_assignments[pos]) == bus:
+                line_name = str(obs.name_line[line_idx])
+                if line_name not in assets["lines"]:
+                    assets["lines"].append(line_name)
+            pos += 1
+
+        for line_idx in line_ex_ids:
+            if pos < len(bus_assignments) and int(bus_assignments[pos]) == bus:
+                line_name = str(obs.name_line[line_idx])
+                if line_name not in assets["lines"]:
+                    assets["lines"].append(line_name)
+            pos += 1
+
+        return assets
+
     def _edge_names_buses_dict(self, obs, action_topo_vect, sub_impacted_id):
         """
         Creates a mapping between line names and their bus assignments.
@@ -1117,8 +1177,18 @@ class ActionDiscoverer:
 
         # Handle both old (float) and new (tuple) return formats for backward compatibility
         if isinstance(result, tuple):
-            return result
-        return result, {}
+            score, details = result
+        else:
+            score, details = result, {}
+
+        # Enrich details with the list of assets on the bus of interest
+        if details and "bus_of_interest" in details:
+            details["assets"] = self._get_assets_on_bus_for_sub(
+                sub_impacted_id, details["bus_of_interest"],
+                bus_assignments=action_topo_vect
+            )
+
+        return score, details
 
 
     def _get_subs_impacted_from_action_desc(self, action_desc: Dict) -> List[int]:
@@ -1279,7 +1349,7 @@ class ActionDiscoverer:
                                    for action_id in map_action_score}
 
 
-    def compute_node_merging_score(self, sub_id: int, connected_buses: list) -> float:
+    def compute_node_merging_score(self, sub_id: int, connected_buses: list) -> Tuple[float, Dict]:
         """
         Computes a heuristic score for a node merging action based on the voltage angle
         difference (delta phase) between the two buses being merged.
@@ -1297,11 +1367,12 @@ class ActionDiscoverer:
             connected_buses: List of connected bus IDs (e.g., [1, 2]).
 
         Returns:
-            float: The delta phase score (theta2 - theta1).
+            Tuple[float, Dict]: The delta phase score and a details dict containing
+                ``red_loop_bus`` and ``assets`` on that bus.
         """
         buses = sorted(connected_buses)
         if len(buses) < 2:
-            return 0.0
+            return 0.0, {}
 
         # Determine which bus carries the red loop (positive dispatch) flow
         # by summing the positive capacity on overflow graph edges per bus
@@ -1340,7 +1411,16 @@ class ActionDiscoverer:
         theta1 = get_theta_node(self.obs_defaut, sub_id, red_loop_bus)
         theta2 = get_theta_node(self.obs_defaut, sub_id, other_bus)
 
-        return theta2 - theta1
+        score = theta2 - theta1
+
+        # Build details with assets on the red loop bus (bus of interest)
+        assets = self._get_assets_on_bus_for_sub(sub_id, red_loop_bus)
+        details = {
+            "red_loop_bus": red_loop_bus,
+            "assets": assets,
+        }
+
+        return score, details
 
     def find_relevant_node_merging(self, nodes_dispatch_path_names: List[str], percentage_threshold_min_dispatch_flow=0.1):
         """
@@ -1359,6 +1439,7 @@ class ActionDiscoverer:
         """
         identified, effective, ineffective = {}, [], []
         scores_map = {}
+        details_map = {}
         capacity_dict = nx.get_edge_attributes(self.g_overflow.g, "capacity")
         max_dispatch_flow=max([abs(val) for val in capacity_dict.values()])
 
@@ -1382,14 +1463,16 @@ class ActionDiscoverer:
                     action_id = f"node_merging_{sub_name}"
                     identified[action_id] = action
 
-                    # Compute delta phase score
+                    # Compute delta phase score and per-action details (including assets)
                     try:
-                        score = self.compute_node_merging_score(sub_id, list(connected_buses))
+                        score, details = self.compute_node_merging_score(sub_id, list(connected_buses))
                         scores_map[action_id] = score
+                        details_map[action_id] = details
                         print(f"  Scored node merge {action_id}: delta_phase={score:.4f}")
                     except Exception as e:
                         print(f"  Warning: Could not score {action_id}: {e}")
                         scores_map[action_id] = 0.0
+                        details_map[action_id] = {}
 
                     if self.check_action_simulation:
                         act_defaut = self._create_default_action(self.action_space, self.lines_defaut)
@@ -1404,10 +1487,7 @@ class ActionDiscoverer:
         self.effective_merges = effective
         self.ineffective_merges = ineffective
         self.scores_merges = scores_map
-        self.params_merges = {
-            "percentage_threshold_min_dispatch_flow": percentage_threshold_min_dispatch_flow,
-            "max_dispatch_flow": max_dispatch_flow,
-        }
+        self.params_merges = details_map
 
 
     # --- Main Orchestration Method ---

--- a/tests/test_ActionDiscoverer.py
+++ b/tests/test_ActionDiscoverer.py
@@ -92,6 +92,13 @@ class MockObservation:
         self.theta_ex = np.array(kwargs.get('theta_ex', np.zeros(num_lines)))
         # --- End added attributes ---
         self.line_status = np.ones(num_lines, dtype=bool)
+        # Load and generator attributes
+        self.name_load = np.array(kwargs.get('name_load', []))
+        self.name_gen = np.array(kwargs.get('name_gen', []))
+        self.load_to_subid = np.array(kwargs.get('load_to_subid', []), dtype=int) if kwargs.get('load_to_subid') is not None else np.array([], dtype=int)
+        self.gen_to_subid = np.array(kwargs.get('gen_to_subid', []), dtype=int) if kwargs.get('gen_to_subid') is not None else np.array([], dtype=int)
+        # Optional: pre-computed per-substation element lists for get_obj_connect_to
+        self._obj_connect_to = kwargs.get('obj_connect_to', None)
 
         class MockLoadP:
             def __init__(self, values): self._values = np.array(values if values is not None else [100.0])
@@ -107,13 +114,23 @@ class MockObservation:
              new_topo = self.topo_vect.copy(); return MockObservation(**{**self.__dict__, 'topo_vect': new_topo}) # Pass existing attrs
         return self
     def get_energy_graph(self): return None
-    # Add mock for get_obj_connect_to needed by get_theta_node
     def get_obj_connect_to(self, substation_id):
-         # Return dummy indices, assuming lines 0, 1 connect if sub_id is 0 or 1
-         if substation_id < 2:
-             return {'lines_or_id': [substation_id], 'lines_ex_id': [substation_id-1 if substation_id > 0 else 1]}
-         else:
-             return {'lines_or_id': [], 'lines_ex_id': []}
+         """Return element indices per substation. Uses explicit mapping if provided."""
+         if self._obj_connect_to and substation_id in self._obj_connect_to:
+             entry = self._obj_connect_to[substation_id]
+             return {
+                 'loads_id': entry.get('loads_id', []),
+                 'generators_id': entry.get('generators_id', []),
+                 'lines_or_id': entry.get('lines_or_id', []),
+                 'lines_ex_id': entry.get('lines_ex_id', []),
+             }
+         # Fallback: auto-derive from line_or/ex_to_subid
+         lines_or = [i for i, s in enumerate(self.line_or_to_subid) if s == substation_id]
+         lines_ex = [i for i, s in enumerate(self.line_ex_to_subid) if s == substation_id]
+         loads = [i for i, s in enumerate(self.load_to_subid) if s == substation_id]
+         gens = [i for i, s in enumerate(self.gen_to_subid) if s == substation_id]
+         return {'loads_id': loads, 'generators_id': gens,
+                 'lines_or_id': lines_or, 'lines_ex_id': lines_ex}
 
 class MockEnv:
     def __init__(self, name_line=None, maintenance_array=None, name_sub=None):
@@ -647,15 +664,23 @@ class TestNodeMergingScore:
     def merging_discoverer(self):
         """Create a discoverer with meaningful theta values for node merging tests."""
         # Sub0 has 2 buses. L1 originates at Sub0 (bus 1), L2 also at Sub0 (bus 2).
+        # Load0 on bus 1, Gen0 on bus 2 at Sub0.
         # L3 connects Sub1->Sub2.
         # Overflow graph: edge (0,1) with L1 has POSITIVE capacity (red loop flow on bus 1),
         # edge (0,1) with L2 has NEGATIVE capacity (on bus 2).
+        #
+        # sub_topology order for Sub0: [Load0_bus, Gen0_bus, L1_or_bus, L2_or_bus]
+        #                              = [1, 2, 1, 2]
         mock_obs = MockObservation(
             name_sub=["Sub0", "Sub1", "Sub2"],
             name_line=["L1", "L2", "L3"],
-            sub_topologies={0: [1, 2], 1: [1, 1], 2: [1, 1]},
-            sub_info=[3, 3, 3],
-            topo_vect=np.array([1, 2, 1, 1, 1, 1, 1, 1, 1]),
+            name_load=["Load0"],
+            name_gen=["Gen0"],
+            load_to_subid=[0],
+            gen_to_subid=[0],
+            sub_topologies={0: [1, 2, 1, 2], 1: [1, 1], 2: [1, 1]},
+            sub_info=[4, 3, 3],
+            topo_vect=np.array([1, 2, 1, 2, 1, 1, 1, 1, 1, 1]),
             line_or_to_subid=[0, 0, 1],
             line_ex_to_subid=[1, 1, 2],
             line_or_bus=[1, 2, 1],
@@ -687,10 +712,13 @@ class TestNodeMergingScore:
             simulator_data={}, check_action_simulation=False
         )
 
-    def test_score_is_float(self, merging_discoverer):
-        """Score should be a float value."""
-        score = merging_discoverer.compute_node_merging_score(0, [1, 2])
+    def test_returns_tuple(self, merging_discoverer):
+        """compute_node_merging_score must return a (float, dict) tuple."""
+        result = merging_discoverer.compute_node_merging_score(0, [1, 2])
+        assert isinstance(result, tuple) and len(result) == 2
+        score, details = result
         assert isinstance(score, float)
+        assert isinstance(details, dict)
 
     def test_red_loop_bus_identified_by_positive_capacity(self, merging_discoverer):
         """Bus carrying positive capacity edges should be identified as red loop bus."""
@@ -700,13 +728,28 @@ class TestNodeMergingScore:
         # theta1 = get_theta_node(obs, 0, 1) = median of theta_or[0] = -5.0
         # theta2 = get_theta_node(obs, 0, 2) = median of theta_or[1] = -1.0
         # score = theta2 - theta1 = -1.0 - (-5.0) = 4.0
-        score = merging_discoverer.compute_node_merging_score(0, [1, 2])
+        score, details = merging_discoverer.compute_node_merging_score(0, [1, 2])
         assert score > 0.0  # theta2 > theta1 means flow towards red loop
+        assert details["red_loop_bus"] == 1
 
     def test_single_bus_returns_zero(self, merging_discoverer):
-        """Should return 0 when fewer than 2 buses."""
-        score = merging_discoverer.compute_node_merging_score(0, [1])
+        """Should return (0.0, {}) when fewer than 2 buses."""
+        score, details = merging_discoverer.compute_node_merging_score(0, [1])
         assert score == 0.0
+        assert details == {}
+
+    def test_details_contains_assets(self, merging_discoverer):
+        """Details dict must contain assets with lines on the red loop bus."""
+        _, details = merging_discoverer.compute_node_merging_score(0, [1, 2])
+        assert "assets" in details
+        assets = details["assets"]
+        assert "lines" in assets
+        assert "loads" in assets
+        assert "generators" in assets
+        # L1 is on bus 1 (red loop bus) at Sub0 origin
+        assert "L1" in assets["lines"]
+        # L2 is on bus 2 (not red loop bus), should not appear
+        assert "L2" not in assets["lines"]
 
 
 # =============================================================================
@@ -752,15 +795,20 @@ class TestDiscoveryParamsStorage:
             assert action_id in params
             assert isinstance(params[action_id], dict)
 
-    def test_merging_params_populated(self, discoverer_instance):
-        """find_relevant_node_merging must populate params_merges with threshold and max flow."""
+    def test_merging_params_populated_per_action(self, discoverer_instance):
+        """find_relevant_node_merging must store per-action params with assets."""
         discoverer_instance.find_relevant_node_merging(["Sub0", "Sub1", "Sub3"])
         params = discoverer_instance.params_merges
-        assert "percentage_threshold_min_dispatch_flow" in params
-        assert "max_dispatch_flow" in params
-        assert isinstance(params["percentage_threshold_min_dispatch_flow"], (int, float))
-        assert isinstance(params["max_dispatch_flow"], (int, float))
-        assert params["max_dispatch_flow"] > 0
+        assert isinstance(params, dict)
+        # Each scored action should have a per-action details entry
+        for action_id in discoverer_instance.scores_merges:
+            assert action_id in params
+            assert isinstance(params[action_id], dict)
+            assert "assets" in params[action_id]
+            assets = params[action_id]["assets"]
+            assert "lines" in assets
+            assert "loads" in assets
+            assert "generators" in assets
 
 
 # =============================================================================
@@ -817,15 +865,19 @@ class TestActionScoresStructureAndRounding:
         discoverer.params_splits_dict = {
             "split_1": {"node_type": "amont", "bus_of_interest": 1,
                         "in_negative_flows": 12.3456, "out_negative_flows": 78.9012,
-                        "in_positive_flows": 0.0, "out_positive_flows": 5.55555},
+                        "in_positive_flows": 0.0, "out_positive_flows": 5.55555,
+                        "assets": {"lines": ["L1"], "loads": [], "generators": []}},
             "split_2": {"node_type": "aval", "bus_of_interest": 2,
                         "in_negative_flows": 99.9999, "out_negative_flows": 1.11111,
-                        "in_positive_flows": 3.33333, "out_positive_flows": 0.0},
+                        "in_positive_flows": 3.33333, "out_positive_flows": 0.0,
+                        "assets": {"lines": ["L2"], "loads": ["Load_X"], "generators": ["Gen_Y"]}},
         }
         discoverer.scores_merges = {"merge_1": 2.71828}
         discoverer.params_merges = {
-            "percentage_threshold_min_dispatch_flow": 0.10000001,
-            "max_dispatch_flow": 987.654321,
+            "merge_1": {
+                "red_loop_bus": 1,
+                "assets": {"lines": ["L1"], "loads": ["Load_A"], "generators": []},
+            },
         }
         return discoverer
 
@@ -863,7 +915,7 @@ class TestActionScoresStructureAndRounding:
         assert action_scores["close_coupling"]["scores"]["merge_1"] == 2.72
 
     def test_flat_params_rounded_to_two_decimals(self, scores_discoverer):
-        """Flat params (reconnections, disconnections, merges) must have floats rounded."""
+        """Flat params (reconnections, disconnections) must have floats rounded."""
         action_scores = self._build_action_scores(scores_discoverer)
         reco_params = action_scores["line_reconnection"]["params"]
         assert reco_params["percentage_threshold_min_dispatch_flow"] == 0.1
@@ -874,11 +926,8 @@ class TestActionScoresStructureAndRounding:
         assert disco_params["max_redispatch"] == 51.0
         assert disco_params["peak_redispatch"] == 42.89
 
-        merge_params = action_scores["close_coupling"]["params"]
-        assert merge_params["max_dispatch_flow"] == 987.65
-
     def test_nested_params_rounded_to_two_decimals(self, scores_discoverer):
-        """Per-action nested params (open_coupling/splits) must have floats rounded."""
+        """Per-action nested params (open/close_coupling) must have floats rounded, non-floats preserved."""
         action_scores = self._build_action_scores(scores_discoverer)
         split_params = action_scores["open_coupling"]["params"]
 
@@ -892,6 +941,12 @@ class TestActionScoresStructureAndRounding:
         s2 = split_params["split_2"]
         assert s2["in_negative_flows"] == 100.0
         assert s2["out_negative_flows"] == 1.11
+
+        # close_coupling (merges) is now per-action too
+        merge_params = action_scores["close_coupling"]["params"]
+        m1 = merge_params["merge_1"]
+        assert m1["red_loop_bus"] == 1  # Int preserved
+        assert isinstance(m1["assets"], dict)  # Dict preserved (not rounded)
 
     def test_empty_scores_produce_empty_entries(self, scores_discoverer):
         """When a category has no scored actions, its scores and params should be empty."""


### PR DESCRIPTION
I understand the scenario. When no line gets overloaded from redispatch (`max_redispatch` stays at `inf`), the current code falls back to `max_overload_flow` and applies the bell curve — but that's wrong because there's no upper danger zone. Instead, the scoring should be a simple ramp: best score (1) at max dispatch flow, decreasing to 0 at `min_redispatch`, negative below.

Now I have the full picture. Here's my plan:

1. **`_compute_disconnection_flow_bounds`**: Return `float('inf')` when unconstrained (remove the fallback)
2. **`compute_disconnection_score`**: Detect `inf` case and use a linear ramp scoring instead of the bell curve
3. **`find_relevant_disconnections`**: Handle `inf` in params output

All done. Here's what was completed:

- **Committed and pushed** the unconstrained disconnection scoring changes (commit `1e0055c`)
- **Updated CHANGELOG.md** with two features added after the release prep:
  - Per-action assets for coupling actions (lines, loads, generators on the scored bus)
  - Unconstrained disconnection scoring regime (linear ramp when `max_redispatch = inf`, with `"regime"` field in params)
  - 7 new `TestUnconstrainedLinearScore` tests documented

All 74 tests pass. The branch `claude/action-scores-dictionary-iz7Lg` is up to date and ready for PR/merge.