### PR TITLE
Externalize thermal limits monitoring factor to configuration

### DIFF
--- a/expert_op4grid_recommender/config.py
+++ b/expert_op4grid_recommender/config.py
@@ -71,6 +71,7 @@ IGNORE_RECONNECTIONS = False
 IGNORE_LINES_MONITORING = False
 LINES_MONITORING_FILE = None
 MAX_RHO_BOTH_EXTREMITIES = False  # only possible for now with pypowsybl backend
+MONITORING_FACTOR_THERMAL_LIMITS = 0.95  # factor applied to permanent thermal limits when loading from operational limits
 
 # Minimum number of prioritized actions per type
 MIN_LINE_RECONNECTIONS = 0

--- a/expert_op4grid_recommender/config_basic.py
+++ b/expert_op4grid_recommender/config_basic.py
@@ -68,6 +68,7 @@ DO_SAVE_DATA_FOR_TEST = False
 CHECK_ACTION_SIMULATION = True
 N_PRIORITIZED_ACTIONS = 5
 IGNORE_RECONNECTIONS = False
+MONITORING_FACTOR_THERMAL_LIMITS = 0.95  # factor applied to permanent thermal limits when loading from operational limits
 
 # -------------------
 #  Expert System Parameters

--- a/expert_op4grid_recommender/main.py
+++ b/expert_op4grid_recommender/main.py
@@ -343,7 +343,7 @@ def run_analysis(analysis_date: Optional[datetime],
                 n_grid = env.backend._grid.network
             else:
                 n_grid = env.network_manager.network
-            env = set_thermal_limits(n_grid, env, thresold_thermal_limit=0.95)
+            env = set_thermal_limits(n_grid, env, thresold_thermal_limit=config.MONITORING_FACTOR_THERMAL_LIMITS)
             obs = env.reset() if backend == Backend.GRID2OP else env.get_obs()
 
     # --- Instantiate Classifier ---

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -71,6 +71,7 @@ IGNORE_RECONNECTIONS = False
 IGNORE_LINES_MONITORING = False
 DO_VISUALIZATION = False  # Skip visualization in tests for faster execution
 MAX_RHO_BOTH_EXTREMITIES = False  # only possible for now with pypowsybl backend
+MONITORING_FACTOR_THERMAL_LIMITS = 0.95  # factor applied to permanent thermal limits when loading from operational limits
 
 # Minimum number of prioritized actions per type
 MIN_LINE_RECONNECTIONS = 0

--- a/tests/test_config_override.py
+++ b/tests/test_config_override.py
@@ -3,6 +3,7 @@ Test to verify config override is working properly.
 Run this test first to debug configuration issues.
 """
 import sys
+import pytest
 
 
 def test_config_is_test_version():
@@ -76,17 +77,108 @@ def test_run_analysis_will_skip_visualization():
     print(f"\n✓ run_analysis will skip visualization (DO_VISUALIZATION={config.DO_VISUALIZATION})")
 
 
+def test_monitoring_factor_thermal_limits_exists():
+    """Verify MONITORING_FACTOR_THERMAL_LIMITS is present in config with default value."""
+    from expert_op4grid_recommender import config
+
+    assert hasattr(config, 'MONITORING_FACTOR_THERMAL_LIMITS'), \
+        "FAIL: MONITORING_FACTOR_THERMAL_LIMITS attribute not found in config"
+
+    assert config.MONITORING_FACTOR_THERMAL_LIMITS == 0.95, \
+        f"FAIL: MONITORING_FACTOR_THERMAL_LIMITS should be 0.95, got {config.MONITORING_FACTOR_THERMAL_LIMITS}"
+
+    print(f"\n✓ MONITORING_FACTOR_THERMAL_LIMITS = {config.MONITORING_FACTOR_THERMAL_LIMITS}")
+
+
+def test_set_thermal_limits_uses_monitoring_factor():
+    """Verify set_thermal_limits applies MONITORING_FACTOR_THERMAL_LIMITS correctly."""
+    np = pytest.importorskip("numpy")
+    pd = pytest.importorskip("pandas")
+    from unittest.mock import MagicMock
+    from expert_op4grid_recommender import config
+    from expert_op4grid_recommender.main import set_thermal_limits
+
+    permanent_limit_value = 1000.0
+    line_name = "LINE_A"
+
+    # Build a mock operational limits DataFrame with a permanent_limit row
+    limits_df = pd.DataFrame({
+        "element_id": [line_name],
+        "name": ["permanent_limit"],
+        "value": [permanent_limit_value],
+    })
+
+    mock_network = MagicMock()
+    mock_network.get_operational_limits.return_value = limits_df.set_index("element_id")
+    mock_network.get_lines.return_value = pd.DataFrame(index=[line_name])
+    mock_network.get_2_windings_transformers.return_value = pd.DataFrame(index=[])
+
+    mock_env = MagicMock()
+    mock_env.name_line = [line_name]
+    mock_env.set_thermal_limit = MagicMock()
+
+    set_thermal_limits(mock_network, mock_env, thresold_thermal_limit=config.MONITORING_FACTOR_THERMAL_LIMITS)
+
+    applied_limits = mock_env.set_thermal_limit.call_args[0][0]
+    expected = np.round(config.MONITORING_FACTOR_THERMAL_LIMITS * permanent_limit_value)
+    assert applied_limits[0] == expected, \
+        f"FAIL: expected thermal limit {expected}, got {applied_limits[0]}"
+
+    print(f"\n✓ set_thermal_limits applied factor {config.MONITORING_FACTOR_THERMAL_LIMITS} correctly "
+          f"({permanent_limit_value} -> {applied_limits[0]})")
+
+
+def test_set_thermal_limits_respects_custom_factor():
+    """Verify set_thermal_limits correctly uses an overridden factor value."""
+    np = pytest.importorskip("numpy")
+    pd = pytest.importorskip("pandas")
+    from unittest.mock import MagicMock
+    from expert_op4grid_recommender.main import set_thermal_limits
+
+    permanent_limit_value = 800.0
+    custom_factor = 0.80
+    line_name = "LINE_B"
+
+    limits_df = pd.DataFrame({
+        "element_id": [line_name],
+        "name": ["permanent_limit"],
+        "value": [permanent_limit_value],
+    })
+
+    mock_network = MagicMock()
+    mock_network.get_operational_limits.return_value = limits_df.set_index("element_id")
+    mock_network.get_lines.return_value = pd.DataFrame(index=[line_name])
+    mock_network.get_2_windings_transformers.return_value = pd.DataFrame(index=[])
+
+    mock_env = MagicMock()
+    mock_env.name_line = [line_name]
+    mock_env.set_thermal_limit = MagicMock()
+
+    set_thermal_limits(mock_network, mock_env, thresold_thermal_limit=custom_factor)
+
+    applied_limits = mock_env.set_thermal_limit.call_args[0][0]
+    expected = np.round(custom_factor * permanent_limit_value)
+    assert applied_limits[0] == expected, \
+        f"FAIL: expected thermal limit {expected} for factor {custom_factor}, got {applied_limits[0]}"
+
+    print(f"\n✓ set_thermal_limits with custom factor {custom_factor}: "
+          f"{permanent_limit_value} -> {applied_limits[0]}")
+
+
 if __name__ == "__main__":
     # Allow running this file directly for debugging
     print("Running config override verification...")
     print("=" * 70)
-    
+
     test_config_is_test_version()
     test_do_visualization_is_false()
     test_config_in_sys_modules()
     test_main_uses_test_config()
     test_run_analysis_will_skip_visualization()
-    
+    test_monitoring_factor_thermal_limits_exists()
+    test_set_thermal_limits_uses_monitoring_factor()
+    test_set_thermal_limits_respects_custom_factor()
+
     print("=" * 70)
     print("✓ ALL VERIFICATION TESTS PASSED!")
     print("=" * 70)


### PR DESCRIPTION
## Summary
This PR extracts the hardcoded thermal limits monitoring factor (0.95) into a configurable parameter, making it easier to adjust the threshold for thermal limit monitoring across different environments without modifying the source code.

## Key Changes
- Added `MONITORING_FACTOR_THERMAL_LIMITS` configuration parameter (default: 0.95) to all configuration files:
  - `config.py` - main configuration
  - `config_basic.py` - basic configuration
  - `tests/config_test.py` - test configuration
- Updated `main.py` to use the new configuration parameter instead of the hardcoded value when setting thermal limits during environment initialization

## Implementation Details
- The factor is applied to permanent thermal limits when loading from operational limits
- Default value of 0.95 maintains backward compatibility with the previous hardcoded behavior
- Configuration is now centralized and can be easily adjusted per environment without code changes

https://claude.ai/code/session_01CgQuhXPeze3cXxPYiDHCoJ