### PR TITLE
Sort identified disconnections by score in discovery

### DIFF
--- a/expert_op4grid_recommender/action_evaluation/discovery.py
+++ b/expert_op4grid_recommender/action_evaluation/discovery.py
@@ -774,7 +774,14 @@ class ActionDiscoverer:
                 ignored.append(action_id)
 
         print(f"  Found {len(effective)} effective, {len(ineffective)} ineffective disconnections.")
-        self.identified_disconnections = identified
+
+        # Sort identified disconnections by score descending (higher score = better candidate)
+        map_action_score_disco = {
+            action_id: {"action": action, "score": scores_map[action_id]}
+            for action_id, action in identified.items()
+        }
+        sorted_actions, _, _ = sort_actions_by_score(map_action_score_disco)
+        self.identified_disconnections = sorted_actions
         self.effective_disconnections = effective
         self.ineffective_disconnections = ineffective
         self.ignored_disconnections = ignored


### PR DESCRIPTION
## Summary
Modified the `find_relevant_disconnections` method to sort identified disconnections by their score in descending order before storing them, ensuring that higher-scoring (better) candidates are prioritized.

## Key Changes
- Added sorting logic to rank identified disconnections by score using the existing `sort_actions_by_score` utility function
- Created a mapping of action IDs to their corresponding actions and scores
- Replaced direct assignment of `identified` with the sorted results from `sort_actions_by_score`
- Maintained all existing disconnection categorizations (effective, ineffective, ignored)

## Implementation Details
The change leverages the existing `sort_actions_by_score` function to consistently order disconnection candidates, improving the quality of recommendations by surfacing the most promising actions first. The sorting is applied only to the identified disconnections while preserving the original categorization logic for effective, ineffective, and ignored disconnections.

https://claude.ai/code/session_01CD2n73srvMn5keKTCNDPmQ