### PR TITLE
Feat: Exclude pre-existing overloads in N-1 analysis unless worsened

### DIFF
--- a/expert_op4grid_recommender/config.py
+++ b/expert_op4grid_recommender/config.py
@@ -30,9 +30,9 @@ PROJECT_ROOT = CONFIG_DIR.parent.resolve()
 # timestep = 32#1#47#18#13#22#9#1#15#1#35#10#14#14#13#22 #1 # 36
 # lines_defaut = "CHALOY631"#"CPVANL61ZMAGN"#"P.SAOL31RONCI"#"COUCHL31VOSNE"#"MAGNYY633"#"CPVANY633"#"CHALOL61CPVAN"#"C.REGL61ZMAGN"#"BEON L31CPVAN"#"CPVANL61ZMAGN"#"CPVANL31RIBAU"#"BEON L31CPVAN"#"MAGNYY633"#"BEON L31CPVAN"##AISERL31RONCI, P.SAOL31RONCI, AISERL31MAGNY, BEON L31CPVAN, "FRON5L31LOUHA"
 
-DATE = datetime(2024, 12, 7)#datetime(2024, 12, 7)#datetime(2024, 9, 19)#datetime(2024, 11, 27)#datetime(2024, 9, 19)#datetime(2024, 11, 27)#datetime(2024, 9, 19)#datetime(2024, 11, 25)#datetime(2024, 11, 25)#datetime(2024, 11, 25)#datetime(2024, 12, 9)#datetime(2024, 12, 2)#datetime(2024, 8, 28)  # we choose a date for the chronic
-TIMESTEP = 9#9#1#15#1#35#10#14#14#13#22 #1 # 36
-LINES_DEFAUT = ["CHALOL61CPVAN"]#"CHALOL61CPVAN"#"C.REGL61ZMAGN"#"BEON L31CPVAN"#"CPVANL61ZMAGN"#"CPVANL31RIBAU"#"BEON L31CPVAN"#"MAGNYY633"#"BEON L31CPVAN"##AISERL31RONCI, P.SAOL31RONCI, AISERL31MAGNY, BEON L31CPVAN, "FRON5L31LOUHA"
+DATE = datetime(2024, 8, 28)#datetime(2024, 12, 7)#datetime(2024, 9, 19)#datetime(2024, 11, 27)#datetime(2024, 9, 19)#datetime(2024, 11, 27)#datetime(2024, 9, 19)#datetime(2024, 11, 25)#datetime(2024, 11, 25)#datetime(2024, 11, 25)#datetime(2024, 12, 9)#datetime(2024, 12, 2)#datetime(2024, 8, 28)  # we choose a date for the chronic
+TIMESTEP = 0#9#1#15#1#35#10#14#14#13#22 #1 # 36
+LINES_DEFAUT = ["P.SAOL31RONCI"]#"CHALOL61CPVAN"#"C.REGL61ZMAGN"#"BEON L31CPVAN"#"CPVANL61ZMAGN"#"CPVANL31RIBAU"#"BEON L31CPVAN"#"MAGNYY633"#"BEON L31CPVAN"##AISERL31RONCI, P.SAOL31RONCI, AISERL31MAGNY, BEON L31CPVAN, "FRON5L31LOUHA"
 CASE_NAME = "defaut_" + "_".join(map(str, LINES_DEFAUT)) + "_t" + str(TIMESTEP)
 
 # -------------------
@@ -40,13 +40,13 @@ CASE_NAME = "defaut_" + "_".join(map(str, LINES_DEFAUT)) + "_t" + str(TIMESTEP)
 # -------------------
 # ENV_FOLDER = "../data" # OLD - Incorrect when run from root
 ENV_FOLDER = PROJECT_ROOT / "data" # NEW - Path relative to project root
-ENV_NAME = "env_dijon_v2_assistant"
+ENV_NAME = "bare_env_small_grid_test"
 ENV_PATH = ENV_FOLDER / ENV_NAME # Use Path object joining
 
 # ACTION_SPACE_FOLDER = os.path.join(ENV_FOLDER,"action_space") # OLD
 ACTION_SPACE_FOLDER = ENV_FOLDER / "action_space" # NEW
 
-FILE_ACTION_SPACE_DESC = "reduced_model_actions.json" #"actions_repas_most_frequent_topologies_revised.json"
+FILE_ACTION_SPACE_DESC = "reduced_model_actions_test.json" #"actions_repas_most_frequent_topologies_revised.json"
 # ACTION_FILE_PATH = os.path.join(ACTION_SPACE_FOLDER, FILE_ACTION_SPACE_DESC) # OLD
 ACTION_FILE_PATH = ACTION_SPACE_FOLDER / FILE_ACTION_SPACE_DESC # NEW
 
@@ -65,13 +65,15 @@ DRAW_ONLY_SIGNIFICANT_EDGES = True
 USE_GRID_LAYOUT = False
 DO_FORCE_OVERLOAD_GRAPH_EVEN_IF_GRAPH_BROKEN_APART = False
 DO_SAVE_DATA_FOR_TEST = False
-CHECK_ACTION_SIMULATION = True
+CHECK_ACTION_SIMULATION = False
 N_PRIORITIZED_ACTIONS = 5
 IGNORE_RECONNECTIONS = False
 IGNORE_LINES_MONITORING = False
 LINES_MONITORING_FILE = None
 MAX_RHO_BOTH_EXTREMITIES = False  # only possible for now with pypowsybl backend
 MONITORING_FACTOR_THERMAL_LIMITS = 0.95  # factor applied to permanent thermal limits when loading from operational limits
+PRE_EXISTING_OVERLOAD_WORSENING_THRESHOLD = 0.02  # 2% – pre-existing overloads excluded from analysis unless current increased by this fraction
+DO_VISUALIZATION=False
 
 # Minimum number of prioritized actions per type
 MIN_LINE_RECONNECTIONS = 0

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -72,6 +72,7 @@ IGNORE_LINES_MONITORING = False
 DO_VISUALIZATION = False  # Skip visualization in tests for faster execution
 MAX_RHO_BOTH_EXTREMITIES = False  # only possible for now with pypowsybl backend
 MONITORING_FACTOR_THERMAL_LIMITS = 0.95  # factor applied to permanent thermal limits when loading from operational limits
+PRE_EXISTING_OVERLOAD_WORSENING_THRESHOLD = 0.02  # 2% – pre-existing overloads excluded from analysis unless current increased by this fraction
 
 # Minimum number of prioritized actions per type
 MIN_LINE_RECONNECTIONS = 0


### PR DESCRIPTION
Based on the implementation plan, this PR introduces a filtering mechanism for N-1 overloads. Lines that are already overloaded in the base N-state are excluded from the N-1 overloads display, analysis, and max_rho processing — unless their maximum current has increased by a specified threshold (default 2% of initial current).

---

# Implementation Plan: Pre-Existing Overloads

Pre-existing overloads (lines already overloaded in N state) should be excluded from N-1 overloads display, contingency analysis, and action `max_rho` — unless worsened by a configurable threshold (default 2% of initial current).

## Proposed Changes

### Expert_op4grid_recommender — Config

#### [MODIFY] config.py
Add `PRE_EXISTING_OVERLOAD_WORSENING_THRESHOLD = 0.02` alongside other config parameters.

---

### Expert_op4grid_recommender — Analysis Engine

#### [MODIFY] main.py

**Overload filtering** (lines 375-389): Already done ✅ — Pre-existing overloads filtered from `lines_overloaded_ids`.

**Store pre-existing rho** (~line 384): Also store a dict `{line_idx: rho_N}` for pre-existing overloads, needed for the worsening check.

**Reassessment max_rho** (lines 579-593): When computing `max_rho` for each action, exclude lines where `obs.rho[i] >= 1` (pre-existing) unless the action's rho exceeds `obs.rho[i] * (1 + threshold)`.

**Return value** (line 614-618): Include `pre_existing_overloads` info in the result dict (list of `{name, rho_N}`).

## Verification Plan

### Automated Tests
- Included tests for `test_pre_existing_overloads_excluded_from_analysis`, `test_pre_existing_overloads_excluded_from_max_rho`, and regression checks.
