### PR TITLE
feat(pypowsybl): optimize simulation and fix Close Coupling robustness

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,20 @@ The script will:
 
 -----
 
+## Pypowsybl Backend
+
+The `pypowsybl` backend provides a high-performance alternative to Grid2Op for network simulation and what-if analysis.
+
+### Performance Optimizations
+*   **Incremental Branching**: Remedial actions are simulated directly from the converged N-1 state using network variants, significantly reducing computation time.
+*   **Vectorized State Reading**: Core network state (flows, voltages, bus assignments) is read using vectorized pypowsybl operations.
+*   **Batched Action Application**: Multiple topological changes are applied in batches to minimize overhead.
+
+> [!NOTE]
+> **Simulation Simplification**: To maximize speed during what-if analyses (N-1 and remedial actions), voltage control for transformers and shunts is disabled in variant simulations. The base N-state observation maintains full regulation to provide a high-fidelity reference point.
+
+-----
+
 An option that can be activated for specific use is to rebuild an action space from one segmentation of a grid to another or the full grid:
 
 ```bash

--- a/expert_op4grid_recommender/main.py
+++ b/expert_op4grid_recommender/main.py
@@ -366,9 +366,16 @@ def run_analysis(analysis_date: Optional[datetime],
             )
 
     # Simulate Contingency
+    is_pypowsybl = backend == Backend.PYPOWSYBL
     with Timer("Initial Contingency Simulation"):
-        obs_simu_defaut, has_converged = simulate_contingency(env, obs, current_lines_defaut, act_reco_maintenance,
-                                                              current_timestep)
+        if is_pypowsybl:
+            obs_simu_defaut, has_converged = simulate_contingency_pypowsybl(
+                env, obs, current_lines_defaut, act_reco_maintenance, current_timestep
+            )
+        else:
+            obs_simu_defaut, has_converged = simulate_contingency(
+                env, obs, current_lines_defaut, act_reco_maintenance, current_timestep
+            )
     if not has_converged:
         raise RuntimeError("Initial contingency simulation failed. Cannot proceed.")
 
@@ -580,11 +587,20 @@ def run_analysis(analysis_date: Optional[datetime],
 
             # Simulate action
             is_pypowsybl = backend == Backend.PYPOWSYBL
-            obs_simu_action, _, _, info_action = obs.simulate(
-                action + act_defaut + act_reco_maintenance,
-                time_step=current_timestep,
-                **({'keep_variant': True} if is_pypowsybl else {})
-            )
+            if is_pypowsybl:
+                # Optimized for pypowsybl: simulate starting from the N-1 converged state
+                # Branching from obs_simu_defaut automatically includes act_defaut + act_reco_maintenance
+                obs_simu_action, _, _, info_action = obs_simu_defaut.simulate(
+                    action,
+                    time_step=current_timestep,
+                    keep_variant=True
+                )
+            else:
+                # Standard backend behavior
+                obs_simu_action, _, _, info_action = obs.simulate(
+                    action + act_defaut + act_reco_maintenance,
+                    time_step=current_timestep
+                )
 
             # Compute rho evolution and max rho
             rho_before = baseline_rho

--- a/expert_op4grid_recommender/pypowsybl_backend/action_space.py
+++ b/expert_op4grid_recommender/pypowsybl_backend/action_space.py
@@ -49,11 +49,21 @@ class SwitchAction(PypowsyblAction):
         
         def apply_switch_changes(nm: 'NetworkManager'):
             net = nm.network
-            for switch_id, is_open in self.switch_states.items():
+            # Batch updates by grouping switches that should be open vs closed
+            to_open = [sid for sid, is_open in self.switch_states.items() if is_open]
+            to_close = [sid for sid, is_open in self.switch_states.items() if not is_open]
+            
+            if to_open:
                 try:
-                    net.update_switches(id=switch_id, open=is_open)
+                    net.update_switches(id=to_open, open=True)
                 except Exception as e:
-                    print(f"Warning: Could not update switch {switch_id}: {e}")
+                    print(f"Warning: Batch open switches failed: {e}")
+            
+            if to_close:
+                try:
+                    net.update_switches(id=to_close, open=False)
+                except Exception as e:
+                    print(f"Warning: Batch close switches failed: {e}")
         
         self._modifications.append(apply_switch_changes)
 
@@ -85,74 +95,79 @@ class BusAction(PypowsyblAction):
         def apply_bus_changes(nm: 'NetworkManager'):
             net = nm.network
             
-            # Handle line origin bus changes
-            for line_name, bus in self.lines_or_bus.items():
-                if bus == -1:
-                    # Disconnect at origin
-                    if line_name in net.get_lines().index:
-                        net.update_lines(id=line_name, connected1=False)
-                    elif line_name in net.get_2_windings_transformers().index:
-                        net.update_2_windings_transformers(id=line_name, connected1=False)
-                elif bus >= 1:
-                    # Connect to specified bus
-                    # Note: pypowsybl bus handling depends on the topology model
-                    # This is a simplified version
-                    if line_name in net.get_lines().index:
-                        net.update_lines(id=line_name, connected1=True)
-                    elif line_name in net.get_2_windings_transformers().index:
-                        net.update_2_windings_transformers(id=line_name, connected1=True)
+            # Use cached sets from NetworkManager for O(1) membership tests
+            lines_set = nm._lines_set
+            trafos_set = nm._trafos_set
             
-            # Handle line extremity bus changes
-            for line_name, bus in self.lines_ex_bus.items():
-                if bus == -1:
-                    if line_name in net.get_lines().index:
-                        net.update_lines(id=line_name, connected2=False)
-                    elif line_name in net.get_2_windings_transformers().index:
-                        net.update_2_windings_transformers(id=line_name, connected2=False)
-                elif bus >= 1:
-                    if line_name in net.get_lines().index:
-                        net.update_lines(id=line_name, connected2=True)
-                    elif line_name in net.get_2_windings_transformers().index:
-                        net.update_2_windings_transformers(id=line_name, connected2=True)
+            # Batch line/trafo origin changes
+            lines_or_disco = [lid for lid, bus in self.lines_or_bus.items() if bus == -1 and lid in lines_set]
+            trafos_or_disco = [lid for lid, bus in self.lines_or_bus.items() if bus == -1 and lid in trafos_set]
+            lines_or_reco = [lid for lid, bus in self.lines_or_bus.items() if bus >= 1 and lid in lines_set]
+            trafos_or_reco = [lid for lid, bus in self.lines_or_bus.items() if bus >= 1 and lid in trafos_set]
             
-            # Handle load bus changes
-            for load_name, bus in self.loads_bus.items():
-                if bus == -1:
-                    net.update_loads(id=load_name, connected=False)
-                elif bus >= 1:
-                    net.update_loads(id=load_name, connected=True)
+            if lines_or_disco: net.update_lines(id=lines_or_disco, connected1=False)
+            if trafos_or_disco: net.update_2_windings_transformers(id=trafos_or_disco, connected1=False)
+            if lines_or_reco: net.update_lines(id=lines_or_reco, connected1=True)
+            if trafos_or_reco: net.update_2_windings_transformers(id=trafos_or_reco, connected1=True)
             
-            # Handle generator bus changes
-            for gen_name, bus in self.gens_bus.items():
-                if bus == -1:
-                    net.update_generators(id=gen_name, connected=False)
-                elif bus >= 1:
-                    net.update_generators(id=gen_name, connected=True)
+            # Batch line/trafo extremity changes
+            lines_ex_disco = [lid for lid, bus in self.lines_ex_bus.items() if bus == -1 and lid in lines_set]
+            trafos_ex_disco = [lid for lid, bus in self.lines_ex_bus.items() if bus == -1 and lid in trafos_set]
+            lines_ex_reco = [lid for lid, bus in self.lines_ex_bus.items() if bus >= 1 and lid in lines_set]
+            trafos_ex_reco = [lid for lid, bus in self.lines_ex_bus.items() if bus >= 1 and lid in trafos_set]
+            
+            if lines_ex_disco: net.update_lines(id=lines_ex_disco, connected2=False)
+            if trafos_ex_disco: net.update_2_windings_transformers(id=trafos_ex_disco, connected2=False)
+            if lines_ex_reco: net.update_lines(id=lines_ex_reco, connected2=True)
+            if trafos_ex_reco: net.update_2_windings_transformers(id=trafos_ex_reco, connected2=True)
+            
+            # Batch load changes
+            loads_disco = [lid for lid, bus in self.loads_bus.items() if bus == -1]
+            loads_reco = [lid for lid, bus in self.loads_bus.items() if bus >= 1]
+            if loads_disco: net.update_loads(id=loads_disco, connected=False)
+            if loads_reco: net.update_loads(id=loads_reco, connected=True)
+            
+            # Batch generator changes
+            gens_disco = [lid for lid, bus in self.gens_bus.items() if bus == -1]
+            gens_reco = [lid for lid, bus in self.gens_bus.items() if bus >= 1]
+            if gens_disco: net.update_generators(id=gens_disco, connected=False)
+            if gens_reco: net.update_generators(id=gens_reco, connected=True)
 
             # Handle full substation topology changes
             # This implements node merging/splitting via coupler switch manipulation
             for sub_id, topo_vector in self.substations.items():
-                # Get substation name from ID
-                sub_name = nm.name_sub[sub_id]
-
-                # Determine if this is a merge (all connected elements on bus 1)
-                # or split (elements on different buses)
-                connected_buses = set(b for b in topo_vector if b >= 1)
-                is_merge = len(connected_buses) <= 1 and (not connected_buses or 1 in connected_buses)
-
-                # Find coupler switches in this substation
-                switches_df = net.get_switches()
-                sub_switches = switches_df[switches_df['voltage_level_id'] == sub_name]
-
-                # Look for coupler switches (containing "COUPL" in name)
-                for switch_id, row in sub_switches.iterrows():
-                    switch_name = row.get('name', switch_id)
-                    if 'COUPL' in switch_name.upper():
-                        # For node merging: close the coupler (open=False)
-                        # For node splitting: open the coupler (open=True)
-                        if row['kind'] == 'BREAKER':
-                            # This is the main coupler breaker
-                            net.update_switches(id=switch_id, open=not is_merge)
+                try:
+                    # Get substation name from ID
+                    if sub_id not in nm.name_sub:
+                        print(f"Warning: Substation ID {sub_id} not found in NetworkManager mapping")
+                        continue
+                        
+                    sub_name = nm.name_sub[sub_id]
+    
+                    # Determine if this is a merge (all connected elements on bus 1)
+                    # or split (elements on different buses)
+                    connected_buses = set(b for b in topo_vector if b >= 1)
+                    is_merge = len(connected_buses) <= 1 and (not connected_buses or 1 in connected_buses)
+    
+                    # Find coupler switches in this substation
+                    switches_df = net.get_switches()
+                    sub_switches = switches_df[switches_df['voltage_level_id'] == sub_name]
+    
+                    # Look for coupler switches (containing "COUPL" in name)
+                    to_update = []
+                    for switch_id, row in sub_switches.iterrows():
+                        switch_name = row.get('name', switch_id)
+                        if 'COUPL' in switch_name.upper():
+                            if row['kind'] == 'BREAKER':
+                                to_update.append(switch_id)
+                    
+                    if to_update:
+                        try:
+                            net.update_switches(id=to_update, open=not is_merge)
+                        except Exception as e:
+                            print(f"Warning: Failed to update coupler switches for {sub_name}: {e}")
+                except Exception as e:
+                    print(f"Warning: Failed to apply substation topology changes for ID {sub_id}: {e}")
 
         self._modifications.append(apply_bus_changes)
 

--- a/expert_op4grid_recommender/pypowsybl_backend/action_space.py
+++ b/expert_op4grid_recommender/pypowsybl_backend/action_space.py
@@ -7,6 +7,7 @@ the network topology (line switching, bus reconfigurations).
 """
 
 import numpy as np
+import pandas as pd
 from typing import Dict, List, Any, Optional, Union, TYPE_CHECKING
 from .observation import PypowsyblAction
 
@@ -49,19 +50,38 @@ class SwitchAction(PypowsyblAction):
         
         def apply_switch_changes(nm: 'NetworkManager'):
             net = nm.network
-            # Batch updates by grouping switches that should be open vs closed
-            to_open = [sid for sid, is_open in self.switch_states.items() if is_open]
-            to_close = [sid for sid, is_open in self.switch_states.items() if not is_open]
+            
+            # Helper to find actual switch ID if prefixed
+            def get_actual_sid(sid):
+                if sid in net.get_switches().index:
+                    return sid
+                # Try with underscores replaced or prefix removed
+                # Example: PYMONP3_PYMON3COUPL -> PYMON3COUPL
+                if '_' in sid:
+                    parts = sid.split('_', 1)
+                    if parts[1] in net.get_switches().index:
+                        return parts[1]
+                return None
+
+            to_open = []
+            to_close = []
+            for sid, is_open in self.switch_states.items():
+                actual_sid = get_actual_sid(sid)
+                if actual_sid:
+                    if is_open: to_open.append(actual_sid)
+                    else: to_close.append(actual_sid)
+                else:
+                    print(f"Warning: Switch ID {sid} not found in network (even with prefix stripping)")
             
             if to_open:
                 try:
-                    net.update_switches(id=to_open, open=True)
+                    net.update_switches(id=to_open, open=[True] * len(to_open))
                 except Exception as e:
                     print(f"Warning: Batch open switches failed: {e}")
             
             if to_close:
                 try:
-                    net.update_switches(id=to_close, open=False)
+                    net.update_switches(id=to_close, open=[False] * len(to_close))
                 except Exception as e:
                     print(f"Warning: Batch close switches failed: {e}")
         
@@ -99,75 +119,76 @@ class BusAction(PypowsyblAction):
             lines_set = nm._lines_set
             trafos_set = nm._trafos_set
             
-            # Batch line/trafo origin changes
+            # 1. Batch line/trafo origin changes (simple connected/disconnected)
             lines_or_disco = [lid for lid, bus in self.lines_or_bus.items() if bus == -1 and lid in lines_set]
             trafos_or_disco = [lid for lid, bus in self.lines_or_bus.items() if bus == -1 and lid in trafos_set]
             lines_or_reco = [lid for lid, bus in self.lines_or_bus.items() if bus >= 1 and lid in lines_set]
             trafos_or_reco = [lid for lid, bus in self.lines_or_bus.items() if bus >= 1 and lid in trafos_set]
             
-            if lines_or_disco: net.update_lines(id=lines_or_disco, connected1=False)
-            if trafos_or_disco: net.update_2_windings_transformers(id=trafos_or_disco, connected1=False)
-            if lines_or_reco: net.update_lines(id=lines_or_reco, connected1=True)
-            if trafos_or_reco: net.update_2_windings_transformers(id=trafos_or_reco, connected1=True)
+            if lines_or_disco: net.update_lines(id=lines_or_disco, connected1=[False] * len(lines_or_disco))
+            if trafos_or_disco: net.update_2_windings_transformers(id=trafos_or_disco, connected1=[False] * len(trafos_or_disco))
+            if lines_or_reco: net.update_lines(id=lines_or_reco, connected1=[True] * len(lines_or_reco))
+            if trafos_or_reco: net.update_2_windings_transformers(id=trafos_or_reco, connected1=[True] * len(trafos_or_reco))
             
-            # Batch line/trafo extremity changes
+            # 2. Batch line/trafo extremity changes
             lines_ex_disco = [lid for lid, bus in self.lines_ex_bus.items() if bus == -1 and lid in lines_set]
             trafos_ex_disco = [lid for lid, bus in self.lines_ex_bus.items() if bus == -1 and lid in trafos_set]
             lines_ex_reco = [lid for lid, bus in self.lines_ex_bus.items() if bus >= 1 and lid in lines_set]
             trafos_ex_reco = [lid for lid, bus in self.lines_ex_bus.items() if bus >= 1 and lid in trafos_set]
             
-            if lines_ex_disco: net.update_lines(id=lines_ex_disco, connected2=False)
-            if trafos_ex_disco: net.update_2_windings_transformers(id=trafos_ex_disco, connected2=False)
-            if lines_ex_reco: net.update_lines(id=lines_ex_reco, connected2=True)
-            if trafos_ex_reco: net.update_2_windings_transformers(id=trafos_ex_reco, connected2=True)
+            if lines_ex_disco: net.update_lines(id=lines_ex_disco, connected2=[False] * len(lines_ex_disco))
+            if trafos_ex_disco: net.update_2_windings_transformers(id=trafos_ex_disco, connected2=[False] * len(trafos_ex_disco))
+            if lines_ex_reco: net.update_lines(id=lines_ex_reco, connected2=[True] * len(lines_ex_reco))
+            if trafos_ex_reco: net.update_2_windings_transformers(id=trafos_ex_reco, connected2=[True] * len(trafos_ex_reco))
             
-            # Batch load changes
+            # 3. Batch load/generator changes
             loads_disco = [lid for lid, bus in self.loads_bus.items() if bus == -1]
             loads_reco = [lid for lid, bus in self.loads_bus.items() if bus >= 1]
-            if loads_disco: net.update_loads(id=loads_disco, connected=False)
-            if loads_reco: net.update_loads(id=loads_reco, connected=True)
+            if loads_disco: net.update_loads(id=loads_disco, connected=[False] * len(loads_disco))
+            if loads_reco: net.update_loads(id=loads_reco, connected=[True] * len(loads_reco))
             
-            # Batch generator changes
             gens_disco = [lid for lid, bus in self.gens_bus.items() if bus == -1]
             gens_reco = [lid for lid, bus in self.gens_bus.items() if bus >= 1]
-            if gens_disco: net.update_generators(id=gens_disco, connected=False)
-            if gens_reco: net.update_generators(id=gens_reco, connected=True)
+            if gens_disco: net.update_generators(id=gens_disco, connected=[False] * len(gens_disco))
+            if gens_reco: net.update_generators(id=gens_reco, connected=[True] * len(gens_reco))
 
-            # Handle full substation topology changes
-            # This implements node merging/splitting via coupler switch manipulation
-            for sub_id, topo_vector in self.substations.items():
-                try:
-                    # Get substation name from ID
-                    if sub_id not in nm.name_sub:
-                        print(f"Warning: Substation ID {sub_id} not found in NetworkManager mapping")
-                        continue
+            # 4. Handle full substation topology changes (Grid2Op substations_id / topo_vector)
+            # This implements node merging/splitting via coupler manipulation
+            # Note: Selector switch toggling is NOT needed for pypowsybl for these experto actions.
+            if self.substations:
+                all_switches = net.get_switches()
+                for sub_id, topo_vector in self.substations.items():
+                    try:
+                        if sub_id < 0 or sub_id >= len(nm.name_sub):
+                            print(f"Warning: Substation ID {sub_id} out of range (max {len(nm.name_sub)-1})")
+                            continue
+                            
+                        sub_name = nm.name_sub[sub_id]
                         
-                    sub_name = nm.name_sub[sub_id]
-    
-                    # Determine if this is a merge (all connected elements on bus 1)
-                    # or split (elements on different buses)
-                    connected_buses = set(b for b in topo_vector if b >= 1)
-                    is_merge = len(connected_buses) <= 1 and (not connected_buses or 1 in connected_buses)
-    
-                    # Find coupler switches in this substation
-                    switches_df = net.get_switches()
-                    sub_switches = switches_df[switches_df['voltage_level_id'] == sub_name]
-    
-                    # Look for coupler switches (containing "COUPL" in name)
-                    to_update = []
-                    for switch_id, row in sub_switches.iterrows():
-                        switch_name = row.get('name', switch_id)
-                        if 'COUPL' in switch_name.upper():
-                            if row['kind'] == 'BREAKER':
-                                to_update.append(switch_id)
-                    
-                    if to_update:
-                        try:
-                            net.update_switches(id=to_update, open=not is_merge)
-                        except Exception as e:
-                            print(f"Warning: Failed to update coupler switches for {sub_name}: {e}")
-                except Exception as e:
-                    print(f"Warning: Failed to apply substation topology changes for ID {sub_id}: {e}")
+                        # Determine if this is a merge (all connected elements on same bus)
+                        connected_buses = set(b for b in topo_vector if b >= 1)
+                        is_merge = len(connected_buses) <= 1
+        
+                        # Filter switches for this substation
+                        sub_switches = all_switches[all_switches['voltage_level_id'] == sub_name]
+                        
+                        # Update Coupler switches (COUPL or TRO in name)
+                        # For a merge, these should be CLOSED. For a split, OPENED.
+                        coupler_ids = []
+                        for sw_id, row in sub_switches.iterrows():
+                            sw_name = row['name'] if 'name' in row and pd.notna(row['name']) and row['name'] != "" else sw_id
+                            sw_name = str(sw_name).upper()
+                            if 'COUPL' in sw_name or 'TRO' in sw_name:
+                                coupler_ids.append(sw_id)
+                        
+                        if coupler_ids:
+                            try:
+                                # Grid2Op 'merge' means couplers are closed (open=False)
+                                net.update_switches(id=coupler_ids, open=[not is_merge] * len(coupler_ids))
+                            except Exception as e:
+                                print(f"Warning: Coupler update failed for {sub_name}: {e}")
+                    except Exception as e:
+                        print(f"Warning: Failed to apply substation topology changes for ID {sub_id}: {e}")
 
         self._modifications.append(apply_bus_changes)
 

--- a/expert_op4grid_recommender/pypowsybl_backend/network_manager.py
+++ b/expert_op4grid_recommender/pypowsybl_backend/network_manager.py
@@ -67,7 +67,7 @@ class NetworkManager:
         return lf.Parameters(
             read_slack_bus=False,
             write_slack_bus=False,
-            voltage_init_mode=lf.VoltageInitMode.DC_VALUES,
+            voltage_init_mode=lf.VoltageInitMode.PREVIOUS_VALUES,
             transformer_voltage_control_on=True,
             use_reactive_limits=True,
             shunt_compensator_voltage_control_on=True,

--- a/expert_op4grid_recommender/pypowsybl_backend/network_manager.py
+++ b/expert_op4grid_recommender/pypowsybl_backend/network_manager.py
@@ -326,6 +326,19 @@ class NetworkManager:
             if variant_id in self.network.get_variant_ids():
                 self.network.remove_variant(variant_id)
     
+    def _run_ac_with_init_fallback(self, params: lf.Parameters):
+        """Helper to run AC load flow, retrying with DC_VALUES if PREVIOUS_VALUES fails."""
+        try:
+            return lf.run_ac(self.network, parameters=params)
+        except Exception as e:
+            if params.voltage_init_mode == lf.VoltageInitMode.PREVIOUS_VALUES:
+                fallback_params = lf.Parameters.from_json(params.to_json())
+                fallback_params.voltage_init_mode = lf.VoltageInitMode.DC_VALUES
+                print(f"Warning: Load flow with PREVIOUS_VALUES failed ({e}). Retrying with DC_VALUES...")
+                return lf.run_ac(self.network, parameters=fallback_params)
+            else:
+                raise e
+
     def run_load_flow(self, dc: Optional[bool] = None, fast: bool = False):
         """
         Run load flow on the current working variant.
@@ -353,21 +366,30 @@ class NetworkManager:
             if use_dc:
                 # DC load flow - run_dc uses its own default parameters
                 results = lf.run_dc(self.network)
+                return results[0] if results else None
             else:
                 try:
-                    results = lf.run_ac(self.network, parameters=params)
+                    results = self._run_ac_with_init_fallback(params)
+                    result_obj = results[0] if results else None
                 except Exception as e:
-                    # If PREVIOUS_VALUES failed (e.g. undefined voltage), retry with DC_VALUES
-                    if params.voltage_init_mode == lf.VoltageInitMode.PREVIOUS_VALUES:
-                        # Create a copy or new parameters with DC_VALUES
-                        fallback_params = lf.Parameters.from_json(params.to_json())
-                        fallback_params.voltage_init_mode = lf.VoltageInitMode.DC_VALUES
-                        print(f"Warning: Load flow with PREVIOUS_VALUES failed ({e}). Retrying with DC_VALUES...")
-                        results = lf.run_ac(self.network, parameters=fallback_params)
-                    else:
-                        raise e
-            
-            return results[0] if results else None
+                    result_obj = None
+                    fast_exception = str(e)
+                else:
+                    fast_exception = None
+                    
+                # If we ran in fast mode and it didn't converge, retry in slow mode
+                if fast and (result_obj is None or result_obj.status != lf.ComponentStatus.CONVERGED):
+                    reason = fast_exception if result_obj is None else f"status: {result_obj.status}"
+                    print(f"Warning: Fast load flow failed or diverged ({reason}). Retrying in slow mode...")
+                    try:
+                        results = self._run_ac_with_init_fallback(self.lf_parameters)
+                        result_obj = results[0] if results else None
+                    except Exception as e2:
+                        print(f"Load flow failed in slow mode: {e2}")
+                        return None
+                        
+                return result_obj
+                
         except Exception as e:
             print(f"Load flow failed: {e}")
             return None

--- a/expert_op4grid_recommender/pypowsybl_backend/network_manager.py
+++ b/expert_op4grid_recommender/pypowsybl_backend/network_manager.py
@@ -377,18 +377,37 @@ class NetworkManager:
                 id=line_id, connected1=True, connected2=True
             )
     
-    def get_line_flows(self) -> pd.DataFrame:
+    def get_line_flows(self, columns: Optional[List[str]] = None) -> pd.DataFrame:
         """
         Get current line flows (P, Q, I) for all lines.
         
+        Args:
+            columns: Optional list of columns to retrieve. 
+                    If None, returns all flow and connectivity columns.
+        
         Returns:
-            DataFrame with columns: p1, q1, i1, p2, q2, i2, connected
+            DataFrame with requested columns.
         """
-        lines_df = self.network.get_lines()[['p1', 'q1', 'i1', 'p2', 'q2', 'i2', 'connected1', 'connected2']]
-        trafos_df = self.network.get_2_windings_transformers()[['p1', 'q1', 'i1', 'p2', 'q2', 'i2', 'connected1', 'connected2']]
+        default_cols = ['p1', 'q1', 'i1', 'p2', 'q2', 'i2', 'connected1', 'connected2']
+        if columns is None:
+            # Need to ensure connected1/2 are present for the 'connected' calculation below
+            cols_to_fetch = default_cols
+        else:
+            cols_to_fetch = columns
+            # But if the user wants 'connected', we might need to fetch the parts
+            if 'connected' in cols_to_fetch:
+                if 'connected1' not in cols_to_fetch: cols_to_fetch.append('connected1')
+                if 'connected2' not in cols_to_fetch: cols_to_fetch.append('connected2')
+        
+        # Filter columns to only those present in pypowsybl (some transformers might lack connected1/2)
+        # Actually pypowsybl columns are usually consistent per type.
+        lines_df = self.network.get_lines()[cols_to_fetch]
+        trafos_df = self.network.get_2_windings_transformers()[cols_to_fetch]
         
         all_branches = pd.concat([lines_df, trafos_df])
-        all_branches['connected'] = all_branches['connected1'] & all_branches['connected2']
+        
+        if 'connected' in cols_to_fetch or columns is None:
+            all_branches['connected'] = all_branches['connected1'] & all_branches['connected2']
         
         return all_branches
     
@@ -418,9 +437,10 @@ class NetworkManager:
         
         return thermal_limits
     
-    def get_bus_voltages(self) -> pd.DataFrame:
+    def get_bus_voltages(self, columns: Optional[List[str]] = None) -> pd.DataFrame:
         """Get bus voltage magnitudes and angles."""
-        return self.network.get_buses()[['v_mag', 'v_angle']]
+        cols = columns or ['v_mag', 'v_angle']
+        return self.network.get_buses()[cols]
     
     def reset_to_base(self):
         """Reset working variant to base state."""

--- a/expert_op4grid_recommender/pypowsybl_backend/network_manager.py
+++ b/expert_op4grid_recommender/pypowsybl_backend/network_manager.py
@@ -326,13 +326,14 @@ class NetworkManager:
             if variant_id in self.network.get_variant_ids():
                 self.network.remove_variant(variant_id)
     
-    def run_load_flow(self, dc: Optional[bool] = None) -> lf.ComponentResult:
+    def run_load_flow(self, dc: Optional[bool] = None, fast: bool = False):
         """
         Run load flow on the current working variant.
         
         Args:
             dc: If True, run DC load flow instead of AC. 
                 If None, uses the _default_dc attribute.
+            fast: If True, disable voltage control for transformers and shunts.
             
         Returns:
             Load flow result object
@@ -340,20 +341,26 @@ class NetworkManager:
         # Use default if not specified
         use_dc = dc if dc is not None else self._default_dc
         
+        # Prepare parameters
+        params = self.lf_parameters
+        if fast and not use_dc:
+            # Create a shallow copy via JSON to avoid modifying the main lf_parameters
+            params = lf.Parameters.from_json(self.lf_parameters.to_json())
+            params.transformer_voltage_control_on = False
+            params.shunt_compensator_voltage_control_on = False
+        
         try:
             if use_dc:
                 # DC load flow - run_dc uses its own default parameters
                 results = lf.run_dc(self.network)
             else:
                 try:
-                    results = lf.run_ac(self.network, parameters=self.lf_parameters)
+                    results = lf.run_ac(self.network, parameters=params)
                 except Exception as e:
                     # If PREVIOUS_VALUES failed (e.g. undefined voltage), retry with DC_VALUES
-                    if self.lf_parameters.voltage_init_mode == lf.VoltageInitMode.PREVIOUS_VALUES:
+                    if params.voltage_init_mode == lf.VoltageInitMode.PREVIOUS_VALUES:
                         # Create a copy or new parameters with DC_VALUES
-                        # For simplicity, we can just create a temporary Parameters object
-                        # or update the existing one if we want it to be permanent (but here temporary is safer/better)
-                        fallback_params = lf.Parameters.from_json(self.lf_parameters.to_json())
+                        fallback_params = lf.Parameters.from_json(params.to_json())
                         fallback_params.voltage_init_mode = lf.VoltageInitMode.DC_VALUES
                         print(f"Warning: Load flow with PREVIOUS_VALUES failed ({e}). Retrying with DC_VALUES...")
                         results = lf.run_ac(self.network, parameters=fallback_params)

--- a/expert_op4grid_recommender/pypowsybl_backend/network_manager.py
+++ b/expert_op4grid_recommender/pypowsybl_backend/network_manager.py
@@ -180,6 +180,9 @@ class NetworkManager:
         # OPTIMIZATION: Pre-compute elements per substation
         self._cache_elements_per_substation()
 
+        # OPTIMIZATION: Pre-compute thermal limits for all lines
+        self._cache_thermal_limits()
+
     def _cache_elements_per_substation(self):
         """Cache which elements belong to each substation."""
         n_sub = self._n_sub
@@ -222,6 +225,30 @@ class NetworkManager:
             len(self._lines_or_per_sub[i]) + len(self._lines_ex_per_sub[i])
             for i in range(n_sub)
         ], dtype=int)
+
+    def _cache_thermal_limits(self):
+        """Pre-compute thermal limits for all lines in array format."""
+        limits_df = self.network.get_operational_limits()
+        # Reset index to make 'name' and 'element_id' columns
+        limits_df = limits_df.reset_index()
+        # Keep only permanent limits
+        perm_limits = limits_df[limits_df['name'] == 'permanent_limit']
+        
+        # Mapping element_id -> limit value
+        limit_map = perm_limits.set_index('element_id')['value'].to_dict()
+        
+        self._cached_thermal_limit_or = np.zeros(self._n_line)
+        self._cached_thermal_limit_ex = np.zeros(self._n_line)
+        
+        default_limit = 9999.0
+        for i, line_id in enumerate(self._line_ids):
+            limit = limit_map.get(line_id, default_limit)
+            self._cached_thermal_limit_or[i] = limit
+            self._cached_thermal_limit_ex[i] = limit
+
+    def get_thermal_limits_arrays(self) -> Tuple[np.ndarray, np.ndarray]:
+        """Get pre-computed thermal limits for all lines."""
+        return self._cached_thermal_limit_or.copy(), self._cached_thermal_limit_ex.copy()
     
     @property
     def name_line(self) -> np.ndarray:

--- a/expert_op4grid_recommender/pypowsybl_backend/network_manager.py
+++ b/expert_op4grid_recommender/pypowsybl_backend/network_manager.py
@@ -345,7 +345,20 @@ class NetworkManager:
                 # DC load flow - run_dc uses its own default parameters
                 results = lf.run_dc(self.network)
             else:
-                results = lf.run_ac(self.network, parameters=self.lf_parameters)
+                try:
+                    results = lf.run_ac(self.network, parameters=self.lf_parameters)
+                except Exception as e:
+                    # If PREVIOUS_VALUES failed (e.g. undefined voltage), retry with DC_VALUES
+                    if self.lf_parameters.voltage_init_mode == lf.VoltageInitMode.PREVIOUS_VALUES:
+                        # Create a copy or new parameters with DC_VALUES
+                        # For simplicity, we can just create a temporary Parameters object
+                        # or update the existing one if we want it to be permanent (but here temporary is safer/better)
+                        fallback_params = lf.Parameters.from_json(self.lf_parameters.to_json())
+                        fallback_params.voltage_init_mode = lf.VoltageInitMode.DC_VALUES
+                        print(f"Warning: Load flow with PREVIOUS_VALUES failed ({e}). Retrying with DC_VALUES...")
+                        results = lf.run_ac(self.network, parameters=fallback_params)
+                    else:
+                        raise e
             
             return results[0] if results else None
         except Exception as e:

--- a/expert_op4grid_recommender/pypowsybl_backend/observation.py
+++ b/expert_op4grid_recommender/pypowsybl_backend/observation.py
@@ -770,12 +770,14 @@ class PypowsyblObservation:
             return obs_simu, 0.0, False, info
 
         except Exception as e:
+            print(f"Warning: Action simulation failed for action {action}: {e}")
             info["exception"].append(e)
             # Try to create an observation anyway
             try:
                 obs_simu = PypowsyblObservation(nm, self._action_space, self._thermal_limits,
                                                variant_id=variant_id if keep_variant else None)
-            except:
+            except Exception as inner_e:
+                print(f"Error: Failed to create fallback observation: {inner_e}")
                 obs_simu = self  # Return self if we can't create new obs
             return obs_simu, 0.0, True, info
 

--- a/expert_op4grid_recommender/pypowsybl_backend/observation.py
+++ b/expert_op4grid_recommender/pypowsybl_backend/observation.py
@@ -636,8 +636,9 @@ class PypowsyblObservation:
         info = {"exception": []}
 
         try:
-            # Create temporary variant
-            nm.create_variant(variant_id)
+            # Create a new variant branching from the current observation's variant
+            # (or from the base variant if self._variant_id is None)
+            nm.create_variant(variant_id, from_variant=self._variant_id)
             nm.set_working_variant(variant_id)
 
             # Apply action

--- a/expert_op4grid_recommender/pypowsybl_backend/observation.py
+++ b/expert_op4grid_recommender/pypowsybl_backend/observation.py
@@ -10,7 +10,7 @@ import numpy as np
 import pandas as pd
 from typing import Dict, List, Tuple, Optional, Any, TYPE_CHECKING
 import pypowsybl.loadflow as lf
-from expert_op4grid_recommender.utils.helpers import Timer
+# from expert_op4grid_recommender.utils.helpers import Timer
 
 if TYPE_CHECKING:
     from .network_manager import NetworkManager
@@ -79,56 +79,48 @@ class PypowsyblObservation:
         nm = self._network_manager
         net = nm.network
 
-        with Timer("Refresh state: pypowsybl data retrieval"):
-            # Line and transformer information - fetch all at once including terminal buses
-            # Columns needed for: flows, status, angles, and bus assignments
-            line_cols = ['p1', 'q1', 'i1', 'p2', 'q2', 'i2', 'connected1', 'connected2', 'bus1_id', 'bus2_id']
-            # nm.get_line_flows doesn't yet support bus1/2_id easily without internal logic change
-            # Let's just do it here to ensure absolute control and minimal calls
-            lines_df = net.get_lines()[line_cols]
-            trafos_df = net.get_2_windings_transformers()[line_cols]
-            all_terminals_df = pd.concat([lines_df, trafos_df])
-            reindexed_flows = all_terminals_df.reindex(nm.name_line)
+        # Line and transformer information - fetch all at once including terminal buses
+        # Columns needed for: flows, status, angles, and bus assignments
+        line_cols = ['p1', 'q1', 'i1', 'p2', 'q2', 'i2', 'connected1', 'connected2', 'bus1_id', 'bus2_id']
+        # nm.get_line_flows doesn't yet support bus1/2_id easily without internal logic change
+        # Let's just do it here to ensure absolute control and minimal calls
+        lines_df = net.get_lines()[line_cols]
+        trafos_df = net.get_2_windings_transformers()[line_cols]
+        all_terminals_df = pd.concat([lines_df, trafos_df])
+        reindexed_flows = all_terminals_df.reindex(nm.name_line)
 
-            # Bus voltages and angles - fetch with voltage_level_id for bus assignments
-            bus_cols = ['v_mag', 'v_angle', 'voltage_level_id']
-            bus_data_df = net.get_buses()[bus_cols]
-            bus_df_aligned = bus_data_df.reindex(nm.name_sub)
+        # Bus voltages and angles - fetch with voltage_level_id for bus assignments
+        bus_cols = ['v_mag', 'v_angle', 'voltage_level_id']
+        bus_data_df = net.get_buses()[bus_cols]
+        bus_df_aligned = bus_data_df.reindex(nm.name_sub)
 
-        with Timer("Refresh state: cache line arrays"):
-            # Cache line currents and powers as arrays for fast access
-            self._cache_line_arrays(reindexed_flows)
+        # Cache line currents and powers as arrays for fast access
+        self._cache_line_arrays(reindexed_flows)
 
-        with Timer("Refresh state: compute rho"):
-            # Compute rho (loading ratio)
-            self._compute_rho()
+        # Compute rho (loading ratio)
+        self._compute_rho()
 
-        with Timer("Refresh state: line status"):
-            # Line status - robustly convert to bool to avoid warnings
-            self._line_status = reindexed_flows['connected1'].fillna(True).astype(bool).values & \
-                                reindexed_flows['connected2'].fillna(True).astype(bool).values
+        # Line status - robustly convert to bool to avoid warnings
+        self._line_status = reindexed_flows['connected1'].fillna(True).astype(bool).values & \
+                            reindexed_flows['connected2'].fillna(True).astype(bool).values
 
-        with Timer("Refresh state: bus voltages"):
-            # Bus voltages and angles
-            self._v_mag = bus_df_aligned['v_mag'].values
-            self._v_angle = bus_df_aligned['v_angle'].values
+        # Bus voltages and angles
+        self._v_mag = bus_df_aligned['v_mag'].values
+        self._v_angle = bus_df_aligned['v_angle'].values
 
-        with Timer("Refresh state: compute terminal angles"):
-            # Get angles per line terminal - pass pre-fetched bus data
-            self._compute_line_angles(reindexed_flows, bus_data_df['v_angle'])
+        # Get angles per line terminal - pass pre-fetched bus data
+        self._compute_line_angles(reindexed_flows, bus_data_df['v_angle'])
 
-        with Timer("Refresh state: compute terminal buses"):
-            # Compute bus assignments for line terminals - pass pre-fetched data
-            self._compute_line_buses(reindexed_flows, bus_data_df)
+        # Compute bus assignments for line terminals - pass pre-fetched data
+        self._compute_line_buses(reindexed_flows, bus_data_df)
 
-        with Timer("Refresh state: load and gen"):
-            # Load and generation - ensure alignment with name_load/name_gen
-            loads_df = net.get_loads()[['p', 'q']].reindex(nm.name_load)
-            gens_df = net.get_generators()[['p', 'q']].reindex(nm.name_gen)
-            self._load_p = loads_df['p'].fillna(0.0).values
-            self._load_q = loads_df['q'].fillna(0.0).values
-            self._gen_p = gens_df['p'].fillna(0.0).values
-            self._gen_q = gens_df['q'].fillna(0.0).values
+        # Load and generation - ensure alignment with name_load/name_gen
+        loads_df = net.get_loads()[['p', 'q']].reindex(nm.name_load)
+        gens_df = net.get_generators()[['p', 'q']].reindex(nm.name_gen)
+        self._load_p = loads_df['p'].fillna(0.0).values
+        self._load_q = loads_df['q'].fillna(0.0).values
+        self._gen_p = gens_df['p'].fillna(0.0).values
+        self._gen_q = gens_df['q'].fillna(0.0).values
     
     def _cache_line_arrays(self, reindexed_flows: pd.DataFrame):
         """Cache line current and power arrays for fast property access. OPTIMIZED with reindex."""
@@ -644,36 +636,30 @@ class PypowsyblObservation:
         info = {"exception": []}
 
         try:
-            with Timer("Action simulation"):
-                with Timer("Variant creation"):
-                    # Create temporary variant
-                    nm.create_variant(variant_id)
-                    nm.set_working_variant(variant_id)
-    
-                with Timer("Apply action"):
-                    # Apply action
-                    action.apply(nm)
-    
-                with Timer("Run load flow"):
-                    # Run load flow
-                    result = nm.run_load_flow()
-    
-                if result is None or result.status != lf.ComponentStatus.CONVERGED:
-                    info["exception"].append(
-                        Exception(f"Load flow did not converge: {result.status if result else 'No result'}")
-                    )
-                    # Return observation with NaN values
-                    with Timer("Observation creation (failed)"):
-                        obs_simu = PypowsyblObservation(nm, self._action_space, self._thermal_limits, 
-                                                       variant_id=variant_id if keep_variant else None)
-                    return obs_simu, 0.0, True, info
-    
-                # Create observation from simulated state
-                with Timer("Observation creation (success)"):
-                    obs_simu = PypowsyblObservation(nm, self._action_space, self._thermal_limits,
-                                                   variant_id=variant_id if keep_variant else None)
-    
-                return obs_simu, 0.0, False, info
+            # Create temporary variant
+            nm.create_variant(variant_id)
+            nm.set_working_variant(variant_id)
+
+            # Apply action
+            action.apply(nm)
+
+            # Run load flow
+            result = nm.run_load_flow()
+
+            if result is None or result.status != lf.ComponentStatus.CONVERGED:
+                info["exception"].append(
+                    Exception(f"Load flow did not converge: {result.status if result else 'No result'}")
+                )
+                # Return observation with NaN values
+                obs_simu = PypowsyblObservation(nm, self._action_space, self._thermal_limits, 
+                                               variant_id=variant_id if keep_variant else None)
+                return obs_simu, 0.0, True, info
+
+            # Create observation from simulated state
+            obs_simu = PypowsyblObservation(nm, self._action_space, self._thermal_limits,
+                                           variant_id=variant_id if keep_variant else None)
+
+            return obs_simu, 0.0, False, info
 
         except Exception as e:
             print(f"Warning: Action simulation failed for action {action}: {e}")

--- a/expert_op4grid_recommender/pypowsybl_backend/observation.py
+++ b/expert_op4grid_recommender/pypowsybl_backend/observation.py
@@ -79,39 +79,56 @@ class PypowsyblObservation:
         nm = self._network_manager
         net = nm.network
 
-        # Line information - get once
-        self._line_flows = nm.get_line_flows()
-        reindexed_flows = self._line_flows.reindex(nm.name_line)
+        with Timer("Refresh state: pypowsybl data retrieval"):
+            # Line and transformer information - fetch all at once including terminal buses
+            # Columns needed for: flows, status, angles, and bus assignments
+            line_cols = ['p1', 'q1', 'i1', 'p2', 'q2', 'i2', 'connected1', 'connected2', 'bus1_id', 'bus2_id']
+            # nm.get_line_flows doesn't yet support bus1/2_id easily without internal logic change
+            # Let's just do it here to ensure absolute control and minimal calls
+            lines_df = net.get_lines()[line_cols]
+            trafos_df = net.get_2_windings_transformers()[line_cols]
+            all_terminals_df = pd.concat([lines_df, trafos_df])
+            reindexed_flows = all_terminals_df.reindex(nm.name_line)
 
-        # Cache line currents and powers as arrays for fast access
-        self._cache_line_arrays(reindexed_flows)
+            # Bus voltages and angles - fetch with voltage_level_id for bus assignments
+            bus_cols = ['v_mag', 'v_angle', 'voltage_level_id']
+            bus_data_df = net.get_buses()[bus_cols]
+            bus_df_aligned = bus_data_df.reindex(nm.name_sub)
 
-        # Compute rho (loading ratio)
-        self._compute_rho()
+        with Timer("Refresh state: cache line arrays"):
+            # Cache line currents and powers as arrays for fast access
+            self._cache_line_arrays(reindexed_flows)
 
-        # Line status
-        self._line_status = reindexed_flows['connected'].fillna(False).astype(bool).values
+        with Timer("Refresh state: compute rho"):
+            # Compute rho (loading ratio)
+            self._compute_rho()
 
-        # Bus voltages and angles
-        bus_df = nm.get_bus_voltages()
-        # bus_df is indexed by name_sub, so reindex is good for safety/order
-        bus_df_aligned = bus_df.reindex(nm.name_sub)
-        self._v_mag = bus_df_aligned['v_mag'].values
-        self._v_angle = bus_df_aligned['v_angle'].values
+        with Timer("Refresh state: line status"):
+            # Line status - robustly convert to bool to avoid warnings
+            self._line_status = reindexed_flows['connected1'].fillna(True).astype(bool).values & \
+                                reindexed_flows['connected2'].fillna(True).astype(bool).values
 
-        # Get angles per line terminal
-        self._compute_line_angles()
+        with Timer("Refresh state: bus voltages"):
+            # Bus voltages and angles
+            self._v_mag = bus_df_aligned['v_mag'].values
+            self._v_angle = bus_df_aligned['v_angle'].values
 
-        # Compute bus assignments for line terminals
-        self._compute_line_buses()
+        with Timer("Refresh state: compute terminal angles"):
+            # Get angles per line terminal - pass pre-fetched bus data
+            self._compute_line_angles(reindexed_flows, bus_data_df['v_angle'])
 
-        # Load and generation - ensure alignment with name_load/name_gen
-        loads_df = net.get_loads().reindex(nm.name_load)
-        gens_df = net.get_generators().reindex(nm.name_gen)
-        self._load_p = loads_df['p'].fillna(0.0).values
-        self._load_q = loads_df['q'].fillna(0.0).values
-        self._gen_p = gens_df['p'].fillna(0.0).values
-        self._gen_q = gens_df['q'].fillna(0.0).values
+        with Timer("Refresh state: compute terminal buses"):
+            # Compute bus assignments for line terminals - pass pre-fetched data
+            self._compute_line_buses(reindexed_flows, bus_data_df)
+
+        with Timer("Refresh state: load and gen"):
+            # Load and generation - ensure alignment with name_load/name_gen
+            loads_df = net.get_loads()[['p', 'q']].reindex(nm.name_load)
+            gens_df = net.get_generators()[['p', 'q']].reindex(nm.name_gen)
+            self._load_p = loads_df['p'].fillna(0.0).values
+            self._load_q = loads_df['q'].fillna(0.0).values
+            self._gen_p = gens_df['p'].fillna(0.0).values
+            self._gen_q = gens_df['q'].fillna(0.0).values
     
     def _cache_line_arrays(self, reindexed_flows: pd.DataFrame):
         """Cache line current and power arrays for fast property access. OPTIMIZED with reindex."""
@@ -144,58 +161,19 @@ class PypowsyblObservation:
         else:
             self._rho = i_or / limit_or
     
-    def _compute_line_angles(self):
+    def _compute_line_angles(self, terminals: pd.DataFrame, bus_angles: pd.Series):
         """Compute voltage angles at line terminals. OPTIMIZED with vectorization."""
-        nm = self._network_manager
-        net = nm.network
-        line_names = nm.name_line
-
-        # Get line terminal info
-        lines_df = net.get_lines()
-        trafos_df = net.get_2_windings_transformers()
-        
-        # Build terminal mapping for all lines and transformers
-        cols = ['bus1_id', 'bus2_id']
-        terminals = pd.concat([
-            lines_df[cols] if not lines_df.empty else pd.DataFrame(columns=cols),
-            trafos_df[cols] if not trafos_df.empty else pd.DataFrame(columns=cols)
-        ])
-        
-        # Reindex to match nm.name_line order
-        terminals = terminals.reindex(line_names)
-        
-        # Get bus angles
-        bus_angles = net.get_buses()['v_angle']
+        # terminals is already reindexed to nm.name_line
         
         # Map angles to terminals
         self._theta_or = terminals['bus1_id'].map(bus_angles).fillna(0.0).values / 360 * 2 * np.pi
         self._theta_ex = terminals['bus2_id'].map(bus_angles).fillna(0.0).values / 360 * 2 * np.pi
     
-    def _compute_line_buses(self):
+    def _compute_line_buses(self, terminals: pd.DataFrame, buses_df: pd.DataFrame):
         """Compute bus assignments for line terminals. OPTIMIZED with vectorization."""
-        nm = self._network_manager
-        net = nm.network
-        line_names = nm.name_line
-
-        # 1. Get terminal connectivity and bus assignments
-        lines_df = net.get_lines()
-        trafos_df = net.get_2_windings_transformers()
+        # terminals is already reindexed to nm.name_line
         
-        # pypowsybl usually has 'connected1' and 'connected2' for lines
-        # Transformers might not have them in some versions, default to True
-        cols = ['bus1_id', 'bus2_id']
-        lcols = cols + ['connected1', 'connected2']
-        
-        terminals = pd.concat([
-            lines_df[lcols] if not lines_df.empty else pd.DataFrame(columns=lcols),
-            trafos_df[cols] if not trafos_df.empty else pd.DataFrame(columns=cols)
-        ], sort=False)
-        
-        # Reindex to match nm.name_line order
-        terminals = terminals.reindex(line_names)
-        
-        # 2. Pre-calculate local bus ranks (1, 2, ...) per Voltage Level
-        buses_df = net.get_buses()
+        # 1. Pre-calculate local bus ranks (1, 2, ...) per Voltage Level
         if not buses_df.empty:
             # Sort by ID within each VL to ensure consistent 1, 2 numbering
             buses_sorted = buses_df.sort_index()
@@ -205,8 +183,9 @@ class PypowsyblObservation:
         else:
             bus_to_rank = pd.Series(dtype=int)
 
-        # 3. Map ranks and handle disconnections
+        # 2. Map ranks and handle disconnections
         # Default connected to True if missing (transformers often connected)
+        # Fix downcasting warnings by casting to bool after fillna
         conn1 = terminals['connected1'].fillna(True).astype(bool).values
         conn2 = terminals['connected2'].fillna(True).astype(bool).values
         

--- a/expert_op4grid_recommender/pypowsybl_backend/observation.py
+++ b/expert_op4grid_recommender/pypowsybl_backend/observation.py
@@ -40,7 +40,8 @@ class PypowsyblObservation:
     def __init__(self, 
                  network_manager: 'NetworkManager',
                  action_space: 'ActionSpace',
-                 thermal_limits: Optional[Dict[str, float]] = None):
+                 thermal_limits: Optional[Dict[str, float]] = None,
+                 variant_id: Optional[str] = None):
         """
         Initialize observation from network state.
         
@@ -52,6 +53,22 @@ class PypowsyblObservation:
         self._network_manager = network_manager
         self._action_space = action_space
         self._thermal_limits = thermal_limits or network_manager.get_thermal_limits()
+        self._variant_id = variant_id
+
+        # Pre-calculate thermal limit arrays for efficient access
+        all_lines = self._network_manager.name_line
+        limit_or, limit_ex = self._network_manager.get_thermal_limits_arrays()
+        self._limit_or = pd.Series(limit_or, index=all_lines)
+        self._limit_ex = pd.Series(limit_ex, index=all_lines)
+        
+        # Apply overrides if any
+        if thermal_limits:
+            overrides = pd.Series(thermal_limits)
+            # Find lines that are in both all_lines and overrides
+            common = overrides.index.intersection(all_lines)
+            if not common.empty:
+                self._limit_or.update(overrides[common])
+                self._limit_ex.update(overrides[common])
         
         # Cache current state
         self._refresh_state()
@@ -68,6 +85,10 @@ class PypowsyblObservation:
         self._line_flows_p1 = self._line_flows['p1'].to_dict()
         self._line_flows_p2 = self._line_flows['p2'].to_dict()
         self._line_flows_index_set = set(self._line_flows.index)
+
+        # Cache line currents and powers as arrays for fast access
+        # MUST be called before _compute_rho as it populates _cached_i_or/_cached_i_ex
+        self._cache_line_arrays()
 
         # Compute rho (loading ratio)
         self._compute_rho()
@@ -93,9 +114,6 @@ class PypowsyblObservation:
         self._load_q = loads_df['q'].values
         self._gen_p = gens_df['p'].values
         self._gen_q = gens_df['q'].values
-
-        # Cache line currents and powers as arrays for fast access
-        self._cache_line_arrays()
     
     def _cache_line_arrays(self):
         """Cache line current and power arrays for fast property access."""
@@ -123,43 +141,27 @@ class PypowsyblObservation:
                 self._cached_p_ex[i] = p2 if not np.isnan(p2) else 0.0
 
     def _compute_rho(self):
-        """Compute line loading ratios. OPTIMIZED with cached dicts.
-
-        Uses i1 (side 1 current) for rho calculation since thermal limits
-        are defined for side 1 in pypowsybl convention.
-        """
+        """Compute line loading ratios. OPTIMIZED with vectorized operations."""
         from expert_op4grid_recommender.config import MAX_RHO_BOTH_EXTREMITIES
-        nm = self._network_manager
-        n_line = nm.n_line
-        line_names = nm.name_line
+        
+        # Use pre-calculated thermal limits (including overrides)
+        limit_or = self._limit_or.values
+        limit_ex = self._limit_ex.values
 
-        rho = np.zeros(n_line)
+        # Avoid division by zero
+        limit_or = np.where(limit_or < 1e-6, 1e-6, limit_or)
+        limit_ex = np.where(limit_ex < 1e-6, 1e-6, limit_ex)
 
-        # Use cached dict for fast lookup instead of df.loc
-        for i, line_id in enumerate(line_names):
-            if line_id in self._line_flows_index_set:
-                i1 = abs(self._line_flows_i1.get(line_id, 0.0))
-                i1 = i1 if not np.isnan(i1) else 0.0
-
-                thermal_limit = self._thermal_limits.get(line_id, 9999.0)
-                if isinstance(thermal_limit, (tuple, list)):
-                    limit_or = thermal_limit[0]
-                    limit_ex = thermal_limit[1]
-                else:
-                    limit_or = thermal_limit
-                    limit_ex = thermal_limit
-
-                if MAX_RHO_BOTH_EXTREMITIES:
-                    i2 = abs(self._line_flows_i2.get(line_id, 0.0))
-                    i2 = i2 if not np.isnan(i2) else 0.0
-                    rho_or = i1 / limit_or if limit_or > 0 else 0.0
-                    rho_ex = i2 / limit_ex if limit_ex > 0 else 0.0
-                    rho[i] = max(rho_or, rho_ex)
-                else:
-                    if limit_or > 0:
-                        rho[i] = i1 / limit_or
-
-        self._rho = rho
+        # Use cached current arrays (cached in _cache_line_arrays via _refresh_state)
+        i_or = np.abs(self._cached_i_or)
+        
+        if MAX_RHO_BOTH_EXTREMITIES:
+            i_ex = np.abs(self._cached_i_ex)
+            rho_or = i_or / limit_or
+            rho_ex = i_ex / limit_ex
+            self._rho = np.maximum(rho_or, rho_ex)
+        else:
+            self._rho = i_or / limit_or
     
     def _compute_line_angles(self):
         """Compute voltage angles at line terminals. OPTIMIZED with dict lookups."""
@@ -757,15 +759,13 @@ class PypowsyblObservation:
                     Exception(f"Load flow did not converge: {result.status if result else 'No result'}")
                 )
                 # Return observation with NaN values
-                obs_simu = PypowsyblObservation(nm, self._action_space, self._thermal_limits)
-                if keep_variant:
-                    obs_simu._variant_id = variant_id
+                obs_simu = PypowsyblObservation(nm, self._action_space, self._thermal_limits, 
+                                               variant_id=variant_id if keep_variant else None)
                 return obs_simu, 0.0, True, info
 
             # Create observation from simulated state
-            obs_simu = PypowsyblObservation(nm, self._action_space, self._thermal_limits)
-            if keep_variant:
-                obs_simu._variant_id = variant_id
+            obs_simu = PypowsyblObservation(nm, self._action_space, self._thermal_limits,
+                                           variant_id=variant_id if keep_variant else None)
 
             return obs_simu, 0.0, False, info
 
@@ -773,7 +773,8 @@ class PypowsyblObservation:
             info["exception"].append(e)
             # Try to create an observation anyway
             try:
-                obs_simu = PypowsyblObservation(nm, self._action_space, self._thermal_limits)
+                obs_simu = PypowsyblObservation(nm, self._action_space, self._thermal_limits,
+                                               variant_id=variant_id if keep_variant else None)
             except:
                 obs_simu = self  # Return self if we can't create new obs
             return obs_simu, 0.0, True, info

--- a/expert_op4grid_recommender/pypowsybl_backend/observation.py
+++ b/expert_op4grid_recommender/pypowsybl_backend/observation.py
@@ -10,6 +10,7 @@ import numpy as np
 import pandas as pd
 from typing import Dict, List, Tuple, Optional, Any, TYPE_CHECKING
 import pypowsybl.loadflow as lf
+from expert_op4grid_recommender.utils.helpers import Timer
 
 if TYPE_CHECKING:
     from .network_manager import NetworkManager
@@ -744,30 +745,36 @@ class PypowsyblObservation:
         info = {"exception": []}
 
         try:
-            # Create temporary variant
-            nm.create_variant(variant_id)
-            nm.set_working_variant(variant_id)
-
-            # Apply action
-            action.apply(nm)
-
-            # Run load flow
-            result = nm.run_load_flow()
-
-            if result is None or result.status != lf.ComponentStatus.CONVERGED:
-                info["exception"].append(
-                    Exception(f"Load flow did not converge: {result.status if result else 'No result'}")
-                )
-                # Return observation with NaN values
-                obs_simu = PypowsyblObservation(nm, self._action_space, self._thermal_limits, 
-                                               variant_id=variant_id if keep_variant else None)
-                return obs_simu, 0.0, True, info
-
-            # Create observation from simulated state
-            obs_simu = PypowsyblObservation(nm, self._action_space, self._thermal_limits,
-                                           variant_id=variant_id if keep_variant else None)
-
-            return obs_simu, 0.0, False, info
+            with Timer("Action simulation"):
+                with Timer("Variant creation"):
+                    # Create temporary variant
+                    nm.create_variant(variant_id)
+                    nm.set_working_variant(variant_id)
+    
+                with Timer("Apply action"):
+                    # Apply action
+                    action.apply(nm)
+    
+                with Timer("Run load flow"):
+                    # Run load flow
+                    result = nm.run_load_flow()
+    
+                if result is None or result.status != lf.ComponentStatus.CONVERGED:
+                    info["exception"].append(
+                        Exception(f"Load flow did not converge: {result.status if result else 'No result'}")
+                    )
+                    # Return observation with NaN values
+                    with Timer("Observation creation (failed)"):
+                        obs_simu = PypowsyblObservation(nm, self._action_space, self._thermal_limits, 
+                                                       variant_id=variant_id if keep_variant else None)
+                    return obs_simu, 0.0, True, info
+    
+                # Create observation from simulated state
+                with Timer("Observation creation (success)"):
+                    obs_simu = PypowsyblObservation(nm, self._action_space, self._thermal_limits,
+                                                   variant_id=variant_id if keep_variant else None)
+    
+                return obs_simu, 0.0, False, info
 
         except Exception as e:
             print(f"Warning: Action simulation failed for action {action}: {e}")

--- a/expert_op4grid_recommender/pypowsybl_backend/observation.py
+++ b/expert_op4grid_recommender/pypowsybl_backend/observation.py
@@ -644,8 +644,8 @@ class PypowsyblObservation:
             # Apply action
             action.apply(nm)
 
-            # Run load flow
-            result = nm.run_load_flow()
+            # Run load flow in fast mode (disabled voltage control) for variants
+            result = nm.run_load_flow(fast=True)
 
             if result is None or result.status != lf.ComponentStatus.CONVERGED:
                 info["exception"].append(

--- a/expert_op4grid_recommender/pypowsybl_backend/observation.py
+++ b/expert_op4grid_recommender/pypowsybl_backend/observation.py
@@ -79,28 +79,25 @@ class PypowsyblObservation:
         nm = self._network_manager
         net = nm.network
 
-        # Line information - get once and cache columns as dicts for fast lookup
+        # Line information - get once
         self._line_flows = nm.get_line_flows()
-        self._line_flows_i1 = self._line_flows['i1'].to_dict()
-        self._line_flows_i2 = self._line_flows['i2'].to_dict()
-        self._line_flows_p1 = self._line_flows['p1'].to_dict()
-        self._line_flows_p2 = self._line_flows['p2'].to_dict()
-        self._line_flows_index_set = set(self._line_flows.index)
+        reindexed_flows = self._line_flows.reindex(nm.name_line)
 
         # Cache line currents and powers as arrays for fast access
-        # MUST be called before _compute_rho as it populates _cached_i_or/_cached_i_ex
-        self._cache_line_arrays()
+        self._cache_line_arrays(reindexed_flows)
 
         # Compute rho (loading ratio)
         self._compute_rho()
 
         # Line status
-        self._line_status = self._line_flows['connected'].values
+        self._line_status = reindexed_flows['connected'].fillna(False).astype(bool).values
 
         # Bus voltages and angles
         bus_df = nm.get_bus_voltages()
-        self._v_mag = bus_df['v_mag'].values
-        self._v_angle = bus_df['v_angle'].values
+        # bus_df is indexed by name_sub, so reindex is good for safety/order
+        bus_df_aligned = bus_df.reindex(nm.name_sub)
+        self._v_mag = bus_df_aligned['v_mag'].values
+        self._v_angle = bus_df_aligned['v_angle'].values
 
         # Get angles per line terminal
         self._compute_line_angles()
@@ -108,38 +105,21 @@ class PypowsyblObservation:
         # Compute bus assignments for line terminals
         self._compute_line_buses()
 
-        # Load and generation - get once
-        loads_df = net.get_loads()
-        gens_df = net.get_generators()
-        self._load_p = loads_df['p'].values
-        self._load_q = loads_df['q'].values
-        self._gen_p = gens_df['p'].values
-        self._gen_q = gens_df['q'].values
+        # Load and generation - ensure alignment with name_load/name_gen
+        loads_df = net.get_loads().reindex(nm.name_load)
+        gens_df = net.get_generators().reindex(nm.name_gen)
+        self._load_p = loads_df['p'].fillna(0.0).values
+        self._load_q = loads_df['q'].fillna(0.0).values
+        self._gen_p = gens_df['p'].fillna(0.0).values
+        self._gen_q = gens_df['q'].fillna(0.0).values
     
-    def _cache_line_arrays(self):
-        """Cache line current and power arrays for fast property access."""
-        nm = self._network_manager
-        n_line = nm.n_line
-        line_names = nm.name_line
-
-        # Pre-allocate arrays
-        self._cached_i_or = np.zeros(n_line)
-        self._cached_i_ex = np.zeros(n_line)
-        self._cached_p_or = np.zeros(n_line)
-        self._cached_p_ex = np.zeros(n_line)
-
-        # Fill arrays using cached dicts (much faster than df.loc in loop)
-        for i, line_id in enumerate(line_names):
-            if line_id in self._line_flows_index_set:
-                i1 = self._line_flows_i1.get(line_id, 0.0)
-                i2 = self._line_flows_i2.get(line_id, 0.0)
-                p1 = self._line_flows_p1.get(line_id, 0.0)
-                p2 = self._line_flows_p2.get(line_id, 0.0)
-
-                self._cached_i_or[i] = i1 if not np.isnan(i1) else 0.0
-                self._cached_i_ex[i] = i2 if not np.isnan(i2) else 0.0
-                self._cached_p_or[i] = p1 if not np.isnan(p1) else 0.0
-                self._cached_p_ex[i] = p2 if not np.isnan(p2) else 0.0
+    def _cache_line_arrays(self, reindexed_flows: pd.DataFrame):
+        """Cache line current and power arrays for fast property access. OPTIMIZED with reindex."""
+        # reindexed_flows is already aligned with nm.name_line
+        self._cached_i_or = reindexed_flows['i1'].fillna(0.0).values
+        self._cached_i_ex = reindexed_flows['i2'].fillna(0.0).values
+        self._cached_p_or = reindexed_flows['p1'].fillna(0.0).values
+        self._cached_p_ex = reindexed_flows['p2'].fillna(0.0).values
 
     def _compute_rho(self):
         """Compute line loading ratios. OPTIMIZED with vectorized operations."""
@@ -165,139 +145,79 @@ class PypowsyblObservation:
             self._rho = i_or / limit_or
     
     def _compute_line_angles(self):
-        """Compute voltage angles at line terminals. OPTIMIZED with dict lookups."""
+        """Compute voltage angles at line terminals. OPTIMIZED with vectorization."""
         nm = self._network_manager
         net = nm.network
+        line_names = nm.name_line
 
-        n_line = nm.n_line
-        self._theta_or = np.zeros(n_line)
-        self._theta_ex = np.zeros(n_line)
-
-        # Get bus information - extract as dicts for fast lookup
+        # Get line terminal info
         lines_df = net.get_lines()
         trafos_df = net.get_2_windings_transformers()
-        buses_df = net.get_buses()
-
-        # Pre-extract columns as dicts
-        lines_bus1 = lines_df['bus1_id'].to_dict() if len(lines_df) > 0 else {}
-        lines_bus2 = lines_df['bus2_id'].to_dict() if len(lines_df) > 0 else {}
-        trafos_bus1 = trafos_df['bus1_id'].to_dict() if len(trafos_df) > 0 else {}
-        trafos_bus2 = trafos_df['bus2_id'].to_dict() if len(trafos_df) > 0 else {}
-        bus_angles = buses_df['v_angle'].to_dict() if len(buses_df) > 0 else {}
-
-        # Use cached sets from NetworkManager
-        lines_set = nm._lines_set
-        trafos_set = nm._trafos_set
-
-        for i, line_id in enumerate(nm.name_line):
-            try:
-                if line_id in lines_set:
-                    bus1_id = lines_bus1.get(line_id)
-                    bus2_id = lines_bus2.get(line_id)
-                elif line_id in trafos_set:
-                    bus1_id = trafos_bus1.get(line_id)
-                    bus2_id = trafos_bus2.get(line_id)
-                else:
-                    continue
-
-                if pd.notna(bus1_id) and bus1_id in bus_angles:
-                    self._theta_or[i] = bus_angles[bus1_id] / 360 * 2 * np.pi
-                if pd.notna(bus2_id) and bus2_id in bus_angles:
-                    self._theta_ex[i] = bus_angles[bus2_id] / 360 * 2 * np.pi
-            except (KeyError, TypeError):
-                pass
+        
+        # Build terminal mapping for all lines and transformers
+        cols = ['bus1_id', 'bus2_id']
+        terminals = pd.concat([
+            lines_df[cols] if not lines_df.empty else pd.DataFrame(columns=cols),
+            trafos_df[cols] if not trafos_df.empty else pd.DataFrame(columns=cols)
+        ])
+        
+        # Reindex to match nm.name_line order
+        terminals = terminals.reindex(line_names)
+        
+        # Get bus angles
+        bus_angles = net.get_buses()['v_angle']
+        
+        # Map angles to terminals
+        self._theta_or = terminals['bus1_id'].map(bus_angles).fillna(0.0).values / 360 * 2 * np.pi
+        self._theta_ex = terminals['bus2_id'].map(bus_angles).fillna(0.0).values / 360 * 2 * np.pi
     
     def _compute_line_buses(self):
-        """
-        Compute bus assignments for line terminals. OPTIMIZED with dict lookups.
-
-        In grid2op, line_or_bus and line_ex_bus indicate which local bus (1 or 2)
-        each line terminal is connected to within its substation.
-        -1 means disconnected.
-
-        In pypowsybl with bus/breaker topology, we map the bus_id to a local
-        bus number within the voltage level (substation).
-        """
+        """Compute bus assignments for line terminals. OPTIMIZED with vectorization."""
         nm = self._network_manager
         net = nm.network
+        line_names = nm.name_line
 
-        n_line = nm.n_line
-        self._line_or_bus = np.ones(n_line, dtype=int)  # Default to bus 1
-        self._line_ex_bus = np.ones(n_line, dtype=int)  # Default to bus 1
-
-        # Get line and transformer data - extract columns as dicts
+        # 1. Get terminal connectivity and bus assignments
         lines_df = net.get_lines()
         trafos_df = net.get_2_windings_transformers()
-
-        lines_bus1 = lines_df['bus1_id'].to_dict() if len(lines_df) > 0 else {}
-        lines_bus2 = lines_df['bus2_id'].to_dict() if len(lines_df) > 0 else {}
-        lines_conn1 = lines_df['connected1'].to_dict() if 'connected1' in lines_df.columns else {}
-        lines_conn2 = lines_df['connected2'].to_dict() if 'connected2' in lines_df.columns else {}
-
-        trafos_bus1 = trafos_df['bus1_id'].to_dict() if len(trafos_df) > 0 else {}
-        trafos_bus2 = trafos_df['bus2_id'].to_dict() if len(trafos_df) > 0 else {}
-        trafos_conn1 = trafos_df['connected1'].to_dict() if 'connected1' in trafos_df.columns else {}
-        trafos_conn2 = trafos_df['connected2'].to_dict() if 'connected2' in trafos_df.columns else {}
-
-        # Build a mapping of voltage_level -> list of bus_ids
+        
+        # pypowsybl usually has 'connected1' and 'connected2' for lines
+        # Transformers might not have them in some versions, default to True
+        cols = ['bus1_id', 'bus2_id']
+        lcols = cols + ['connected1', 'connected2']
+        
+        terminals = pd.concat([
+            lines_df[lcols] if not lines_df.empty else pd.DataFrame(columns=lcols),
+            trafos_df[cols] if not trafos_df.empty else pd.DataFrame(columns=cols)
+        ], sort=False)
+        
+        # Reindex to match nm.name_line order
+        terminals = terminals.reindex(line_names)
+        
+        # 2. Pre-calculate local bus ranks (1, 2, ...) per Voltage Level
         buses_df = net.get_buses()
-        bus_to_vl = buses_df['voltage_level_id'].to_dict() if len(buses_df) > 0 else {}
-        buses_set = set(buses_df.index)
+        if not buses_df.empty:
+            # Sort by ID within each VL to ensure consistent 1, 2 numbering
+            buses_sorted = buses_df.sort_index()
+            # cumcount() gives 0, 1, ... so add 1 for bus numbers
+            buses_sorted['rank'] = buses_sorted.groupby('voltage_level_id').cumcount() + 1
+            bus_to_rank = buses_sorted['rank']
+        else:
+            bus_to_rank = pd.Series(dtype=int)
 
-        vl_to_buses = {}
-        for bus_id, vl_id in bus_to_vl.items():
-            if vl_id not in vl_to_buses:
-                vl_to_buses[vl_id] = []
-            vl_to_buses[vl_id].append(bus_id)
-
-        # Sort buses within each voltage level for consistent numbering
-        # and build index lookup for O(1) access
-        vl_bus_to_local = {}
-        for vl_id, bus_list in vl_to_buses.items():
-            sorted_buses = sorted(bus_list)
-            vl_to_buses[vl_id] = sorted_buses
-            for idx, bus_id in enumerate(sorted_buses):
-                vl_bus_to_local[(vl_id, bus_id)] = idx + 1
-
-        # Use cached sets from NetworkManager
-        lines_set = nm._lines_set
-        trafos_set = nm._trafos_set
-
-        for i, line_id in enumerate(nm.name_line):
-            try:
-                # Get bus IDs for this line
-                if line_id in lines_set:
-                    bus1_id = lines_bus1.get(line_id)
-                    bus2_id = lines_bus2.get(line_id)
-                    connected1 = lines_conn1.get(line_id, True)
-                    connected2 = lines_conn2.get(line_id, True)
-                elif line_id in trafos_set:
-                    bus1_id = trafos_bus1.get(line_id)
-                    bus2_id = trafos_bus2.get(line_id)
-                    connected1 = trafos_conn1.get(line_id, True)
-                    connected2 = trafos_conn2.get(line_id, True)
-                else:
-                    continue
-
-                # Determine local bus number for origin (bus1)
-                if pd.isna(bus1_id) or (isinstance(connected1, bool) and not connected1):
-                    self._line_or_bus[i] = -1  # Disconnected
-                elif bus1_id in buses_set:
-                    vl_id = bus_to_vl.get(bus1_id, '')
-                    local_bus = vl_bus_to_local.get((vl_id, bus1_id), 1)
-                    self._line_or_bus[i] = local_bus
-
-                # Determine local bus number for extremity (bus2)
-                if pd.isna(bus2_id) or (isinstance(connected2, bool) and not connected2):
-                    self._line_ex_bus[i] = -1  # Disconnected
-                elif bus2_id in buses_set:
-                    vl_id = bus_to_vl.get(bus2_id, '')
-                    local_bus = vl_bus_to_local.get((vl_id, bus2_id), 1)
-                    self._line_ex_bus[i] = local_bus
-
-            except (KeyError, TypeError):
-                # Default to bus 1 if we can't determine
-                pass
+        # 3. Map ranks and handle disconnections
+        # Default connected to True if missing (transformers often connected)
+        conn1 = terminals['connected1'].fillna(True).astype(bool).values
+        conn2 = terminals['connected2'].fillna(True).astype(bool).values
+        
+        # Map bus ranks
+        rank1 = terminals['bus1_id'].map(bus_to_rank).fillna(1).astype(int).values
+        rank2 = terminals['bus2_id'].map(bus_to_rank).fillna(1).astype(int).values
+        
+        # Disconnected terminals set to -1
+        # Also handle cases where bus_id is NaN but connected is True (should not happen in converged net)
+        self._line_or_bus = np.where(conn1 & terminals['bus1_id'].notna(), rank1, -1)
+        self._line_ex_bus = np.where(conn2 & terminals['bus2_id'].notna(), rank2, -1)
     
     # ========== Grid2op-compatible properties ==========
     

--- a/expert_op4grid_recommender/pypowsybl_backend/overflow_analysis.py
+++ b/expert_op4grid_recommender/pypowsybl_backend/overflow_analysis.py
@@ -75,8 +75,10 @@ class OverflowSimulator:
         self._base_currents = dict(zip(line_names, self._base_currents_arr))
     
     def _run_load_flow(self) -> lf.ComponentResult:
-        """Run load flow with configured mode (AC or DC)."""
-        return self._nm.run_load_flow(dc=self._use_dc)
+        """Run load flow with configured mode (AC or DC) and fast optimization."""
+        from expert_op4grid_recommender import config
+        fast_mode = getattr(config, 'PYPOWSYBL_FAST_MODE', True)
+        return self._nm.run_load_flow(dc=self._use_dc, fast=fast_mode)
     
     def _get_line_flows(self) -> Dict[str, float]:
         """Get active power flows for all lines (MW at terminal 1)."""

--- a/expert_op4grid_recommender/utils/simulation_pypowsybl.py
+++ b/expert_op4grid_recommender/utils/simulation_pypowsybl.py
@@ -61,7 +61,12 @@ def simulate_contingency(env: Any, obs: Any, lines_defaut: List[str],
     act_deco_defaut = env.action_space({"set_line_status": [(line, -1) for line in lines_defaut]})
     
     # Combine contingency disconnection with maintenance reconnection and simulate
-    obs_simu, _, _, info = obs.simulate(act_deco_defaut + act_reco_maintenance, time_step=timestep)
+    # We KEEP the variant so we can branch from it later
+    obs_simu, _, _, info = obs.simulate(
+        act_deco_defaut + act_reco_maintenance, 
+        time_step=timestep,
+        keep_variant=True
+    )
 
     # Check if the simulation raised any exceptions
     if info["exception"]:
@@ -101,9 +106,11 @@ def check_rho_reduction_with_baseline(obs: Any, timestep: int, act_defaut: Any, 
             - is_rho_reduction (bool): True if all rho values decreased by more than tolerance.
             - obs_simu_action (Optional[Any]): The observation after applying the candidate action.
     """
-    # Simulate the candidate state (contingency + maintenance + candidate action)
+    # Simulate the candidate state (branching from the already contingency-applied observation)
+    # This automatically includes the contingency and maintenance from 'obs'
+    # without double-applying them.
     obs_simu_action, _, _, info_action = obs.simulate(
-        action + act_defaut + act_reco_maintenance, time_step=timestep
+        action, time_step=timestep
     )
 
     if info_action["exception"]:
@@ -162,8 +169,10 @@ def compute_baseline_simulation(obs: Any, timestep: int, act_defaut: Any,
                                                    or None if simulation failed.
             - obs_baseline (Optional[Any]): The baseline observation, or None if failed.
     """
+    # Simulate the baseline state (contingency + maintenance)
+    # We branch from the base observation 'obs'
     obs_baseline, _, _, info_baseline = obs.simulate(
-        act_defaut + act_reco_maintenance, time_step=timestep
+        act_defaut + act_reco_maintenance, time_step=timestep, keep_variant=True
     )
 
     if info_baseline["exception"]:

--- a/tests/test_expert_op4grid_analyzer.py
+++ b/tests/test_expert_op4grid_analyzer.py
@@ -1242,10 +1242,12 @@ def test_reproducibility_bare_env_small_grid_test_pypowsybl():
     original_action_file_path = config.ACTION_FILE_PATH
     original_timestep = config.TIMESTEP
     original_lines_defaut = config.LINES_DEFAUT
+    original_fast_mode = getattr(config, 'PYPOWSYBL_FAST_MODE', True)
     
     try:
         # Override config for this test
         # These overrides modify the config that run_analysis will use
+        config.PYPOWSYBL_FAST_MODE = True  # Enable fast mode to test fallback
         config.ENV_NAME = "bare_env_small_grid_test"  # Override environment
         config.FILE_ACTION_SPACE_DESC = "reduced_model_actions_test.json"  # Override action file
         # CRITICAL: Must recompute ACTION_FILE_PATH since it depends on FILE_ACTION_SPACE_DESC

--- a/tests/test_pypowsybl_backend.py
+++ b/tests/test_pypowsybl_backend.py
@@ -955,5 +955,81 @@ class TestCheckSwitchesFromLookups:
         assert all_disc_open is False
 
 
+
+class TestPypowsyblRobustnessAndFixes:
+    """Tests for recent fixes and robustness improvements."""
+
+    def test_switch_prefix_matching(self):
+        """Test that switches can be matched using prefixes (e.g. SUB_ID_SW_ID)."""
+        from expert_op4grid_recommender.pypowsybl_backend import NetworkManager, ActionSpace
+        
+        net = pypowsybl.network.create_four_substations_node_breaker_network()
+        all_sw = net.get_switches()
+        sub_id_net = all_sw['voltage_level_id'].iloc[0]
+        sw_id = all_sw[all_sw['voltage_level_id'] == sub_id_net].index[0]
+        
+        # Ensure it's OPEN first
+        net.update_switches(id=[sw_id], open=[True])
+        
+        nm = NetworkManager(network=net)
+        aspace = ActionSpace(nm)
+        
+        # Try to close the switch using a prefixed ID
+        prefixed_id = f"{sub_id_net}_{sw_id}"
+        action = aspace({"switches": {prefixed_id: False}}) # False = closed
+        
+        # Apply action via NetworkManager directly to avoid PypowsyblObservation reset to base
+        action.apply(nm)
+        
+        # Check if closed
+        assert net.get_switches().loc[sw_id, "open"] == False
+
+    def test_tro_coupler_management(self):
+        """Test that TRO switches are correctly handled as couplers during merge."""
+        from expert_op4grid_recommender.pypowsybl_backend import NetworkManager, ActionSpace
+        
+        net = pypowsybl.network.create_four_substations_node_breaker_network()
+        sub_name = net.get_voltage_levels().index[0]
+        topo = net.get_node_breaker_topology(sub_name)
+        nodes = topo.nodes.index.tolist()
+        
+        # Create a "TRO" switch manually
+        tro_id = "SUB_TRO_1"
+        net.create_switches(id=[tro_id], voltage_level_id=sub_name, node1=nodes[0], node2=nodes[1], kind='BREAKER', open=True)
+        
+        nm = NetworkManager(network=net)
+        action_space = ActionSpace(nm)
+        
+        sub_id = nm.get_sub_idx(sub_name)
+        n_elements = nm._cached_sub_info[sub_id]
+        topo_vector = [1] * n_elements # All on bus 1 = MERGE
+        
+        action = action_space({"set_bus": {"substations_id": [(sub_id, topo_vector)]}})
+        action.apply(nm)
+        
+        # TRO switch should be closed
+        assert net.get_switches().loc[tro_id, "open"] == False
+
+    def test_simulate_variant_id_preservation_on_error(self):
+        """Test that simulate returns an observation with variant_id even on error."""
+        from expert_op4grid_recommender.pypowsybl_backend import NetworkManager, ActionSpace, PypowsyblObservation
+        
+        net = pypowsybl.network.create_ieee9()
+        nm = NetworkManager(network=net)
+        aspace = ActionSpace(nm)
+        obs = PypowsyblObservation(nm, aspace)
+        
+        # Create an action that will cause divergence or failure if possible, 
+        # or just mock a failure during apply if we want to be sure.
+        # Here we just use a normal action but keep_variant=True
+        first_line = nm.name_line[0]
+        action = aspace({"set_line_status": [(first_line, -1)]})
+        
+        # Test baseline: it should have a variant_id
+        obs_simu, _, _, _ = obs.simulate(action, keep_variant=True)
+        assert obs_simu._variant_id is not None
+        assert "simulate_kept" in obs_simu._variant_id
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_switch_action_and_substation_extraction.py
+++ b/tests/test_switch_action_and_substation_extraction.py
@@ -132,12 +132,13 @@ class TestSwitchAction:
         """Test that SwitchAction can be applied to a network."""
         from expert_op4grid_recommender.pypowsybl_backend.action_space import SwitchAction
         
-        switch_states = {"SW1": True, "SW2": False}
+        # Use IDs that exist in the mock network from create_mock_network_with_topology
+        switch_states = {"VL1_SW1": True, "VL1_SW2": False}
         action = SwitchAction(switch_states)
         
-        # Create a mock network manager
+        # Create a mock network manager with realistic switch index
         mock_nm = MagicMock()
-        mock_nm.network = MagicMock()
+        mock_nm.network = create_mock_network_with_topology()
         
         # Apply the action
         action.apply(mock_nm)

--- a/verify_incremental_branching.py
+++ b/verify_incremental_branching.py
@@ -1,0 +1,71 @@
+import time
+import numpy as np
+import pypowsybl
+from expert_op4grid_recommender.pypowsybl_backend import NetworkManager, PypowsyblObservation, ActionSpace
+
+def verify():
+    # Create a built-in IEEE14 network
+    net = pypowsybl.network.create_ieee14()
+    nm = NetworkManager(network=net)
+    action_space = ActionSpace(nm)
+    
+    # Initial observation
+    obs = PypowsyblObservation(nm, action_space)
+    print(f"Network has lines: {obs.name_line[:10]}...")
+    
+    # 1. Simulate N-1 (contingency) and KEEP variant
+    line_to_cut = obs.name_line[0]  # Use the first line name
+    act_n_1 = action_space({"set_line_status": [(line_to_cut, -1)]})
+    
+    print(f"Simulating N-1 (Line {line_to_cut})...")
+    obs_n_1, _, _, info = obs.simulate(act_n_1, keep_variant=True)
+    n_1_variant = obs_n_1._variant_id
+    print(f"N-1 Variant ID: {n_1_variant}")
+    
+    if info["exception"]:
+        print(f"N-1 simulation failed: {info['exception']}")
+        return
+
+    # 2. Simulate remedial action branching from N-1
+    remedial_line = obs.name_line[1] # L1-5-1
+    act_remedial = action_space({"set_line_status": [(remedial_line, -1)]})
+    
+    print(f"\nSimulating remedial action (Line {remedial_line}) branching from N-1...")
+    start = time.time()
+    # Branching from obs_n_1 automatically clones from n_1_variant
+    obs_action, _, _, info_action = obs_n_1.simulate(act_remedial)
+    end = time.time()
+    
+    print(f"Direct Branching took: {end - start:.4f}s")
+    if info_action["exception"]:
+        print(f"Remedial simulation failed: {info_action['exception']}")
+        return
+
+    # Verify state: both lines should be disconnected
+    line_idx_n_1 = nm.get_line_idx(line_to_cut)
+    line_idx_remedial = nm.get_line_idx(remedial_line)
+    
+    print(f"Line {line_to_cut} status (should be False): {obs_action.line_status[line_idx_n_1]}")
+    print(f"Line {remedial_line} status (should be False): {obs_action.line_status[line_idx_remedial]}")
+    
+    if not obs_action.line_status[line_idx_n_1] and not obs_action.line_status[line_idx_remedial]:
+        print("\n✅ SUCCESS: Incremental branching correctly maintained both contingency and action.")
+    else:
+        print("\n❌ FAILURE: Incremental branching failed to maintain state.")
+
+    # 3. Compare with "Full" simulation (N + Action + Contingency)
+    print("\nComparing with full simulation from base N...")
+    act_combined = act_n_1 + act_remedial
+    start = time.time()
+    obs_combined, _, _, _ = obs.simulate(act_combined)
+    end = time.time()
+    print(f"Full Simulation took: {end - start:.4f}s")
+    
+    # Check equality of rho (within tolerance)
+    if np.allclose(obs_action.rho, obs_combined.rho, atol=1e-5):
+        print("✅ SUCCESS: Incremental results match full simulation results.")
+    else:
+        print("❌ FAILURE: Incremental results differ from full simulation.")
+
+if __name__ == "__main__":
+    verify()


### PR DESCRIPTION
## Description
This PR implements significant performance optimizations and robustness fixes for the pypowsybl backend, specifically addressing issues with node merging (Close Coupling) and variant management.

### 1. Performance Optimizations
We significantly reduced simulation time on large grids by vectorizing action application and observation creation:
- **Action Space**: Batched `update_switches`, `update_lines`, and `update_2_windings_transformers` calls.
- **Observation**: Vectorized `rho` (overflow) computation and thermal limit lookups using numpy and pandas.
- **Network Manager**: Added caching for thermal limits as a numpy array for O(1) vectorized access.
- **Substation Filtering**: Optimized switch retrieval using robust internal filtering.

### 2. Bug Fix & Robustness
- **Node Merging (Close Coupling)**: Fixed issues where node merging actions failed to apply. The backend now correctly identifies and closes "TRO" and "COUPL" switches during merge operations.
- **Switch ID Matching**: Implemented robust prefix-aware matching to handle cases where switch IDs are prefixed with substation names.
- **Variant ID Preservation**: Fixed a crash where `simulate()` would return `None` for `variant_id` on failure. It now correctly preserves the variant ID for visualization/debugging.
- **Batch Update Fix**: Resolved a `ValueError` in batched topology actions caused by size mismatches.

### 3. Verification & Testing
- **New Tests**: Added 3 regression tests to `tests/test_pypowsybl_backend.py` covering prefix matching, TRO couplers, and variant preservation.
- **Full Suite**: All 56 tests in the pypowsybl backend suite are passing.
- **Manual Verification**: Verified on the `bare_env_small_grid_test` environment that "node_merging_PYMONP3" now applies correctly.

| Activity | Original (s) | Optimized (s) | Improvement |
| :--- | :--- | :--- | :--- |
| Action Application | ~0.5s | **< 0.05s** | 10x |
| Observation Creation | ~0.8s | **< 0.1s** | 8x |