### PR TITLE
feat: propagate fast_mode parameter to pypowsybl backend

### DIFF
--- a/expert_op4grid_recommender/main.py
+++ b/expert_op4grid_recommender/main.py
@@ -170,18 +170,18 @@ def switch_to_dc_pypowsybl(env, analysis_date, current_timestep, current_lines_d
                                              maintenance_to_reco_at_t)
 
 
-def simulate_contingency_pypowsybl(env, obs, lines_defaut, act_reco_maintenance, timestep):
+def simulate_contingency_pypowsybl(env, obs, lines_defaut, act_reco_maintenance, timestep, fast_mode=True):
     """Simulate contingency using pypowsybl."""
     from expert_op4grid_recommender.utils.simulation_pypowsybl import simulate_contingency
-    return simulate_contingency(env, obs, lines_defaut, act_reco_maintenance, timestep)
+    return simulate_contingency(env, obs, lines_defaut, act_reco_maintenance, timestep, fast_mode=fast_mode)
 
 
 def check_simu_overloads_pypowsybl(obs, obs_defaut, action_space, timestep, lines_defaut,
-                                    lines_overloaded_ids_kept, maintenance_to_reco_at_t):
+                                    lines_overloaded_ids_kept, maintenance_to_reco_at_t, fast_mode=True):
     """Check simulation overloads using pypowsybl."""
     from expert_op4grid_recommender.utils.simulation_pypowsybl import check_simu_overloads
     return check_simu_overloads(obs, obs_defaut, action_space, timestep, lines_defaut,
-                                 lines_overloaded_ids_kept, maintenance_to_reco_at_t)
+                                 lines_overloaded_ids_kept, maintenance_to_reco_at_t, fast_mode=fast_mode)
 
 
 def create_default_action_pypowsybl(action_space, defauts):
@@ -191,38 +191,38 @@ def create_default_action_pypowsybl(action_space, defauts):
 
 
 def check_rho_reduction_pypowsybl(obs, timestep, act_defaut, action, overload_ids,
-                                   act_reco_maintenance, lines_we_care_about):
+                                   act_reco_maintenance, lines_we_care_about, fast_mode=True):
     """Check rho reduction using pypowsybl."""
     from expert_op4grid_recommender.utils.simulation_pypowsybl import check_rho_reduction
     return check_rho_reduction(obs, timestep, act_defaut, action, overload_ids,
-                                act_reco_maintenance, lines_we_care_about)
+                                act_reco_maintenance, lines_we_care_about, fast_mode=fast_mode)
 
 
-def compute_baseline_simulation_pypowsybl(obs, timestep, act_defaut, act_reco_maintenance, overload_ids):
+def compute_baseline_simulation_pypowsybl(obs, timestep, act_defaut, act_reco_maintenance, overload_ids, fast_mode=True):
     """Compute baseline simulation using pypowsybl."""
     from expert_op4grid_recommender.utils.simulation_pypowsybl import compute_baseline_simulation
-    return compute_baseline_simulation(obs, timestep, act_defaut, act_reco_maintenance, overload_ids)
+    return compute_baseline_simulation(obs, timestep, act_defaut, act_reco_maintenance, overload_ids, fast_mode=fast_mode)
 
 
 def build_overflow_graph_pypowsybl(env, obs_simu_defaut, lines_overloaded_ids_kept,
                                     non_connected_reconnectable_lines, lines_non_reconnectable,
-                                    timestep, do_consolidate_graph, use_dc=False):
+                                    timestep, do_consolidate_graph, use_dc=False, fast_mode=True):
     """Build overflow graph using pypowsybl."""
     from expert_op4grid_recommender.pypowsybl_backend.overflow_analysis import build_overflow_graph_pypowsybl as _build
     return _build(env, obs_simu_defaut, lines_overloaded_ids_kept,
                   non_connected_reconnectable_lines, lines_non_reconnectable,
-                  timestep, do_consolidate_graph=do_consolidate_graph, use_dc=use_dc)
+                  timestep, do_consolidate_graph=do_consolidate_graph, use_dc=use_dc, param_options={"fast_mode": fast_mode})
 
 
 def build_overflow_graph_pypowsybl_wrapper(env, obs_simu_defaut, lines_overloaded_ids_kept,
                                            non_connected_reconnectable_lines, lines_non_reconnectable,
-                                           timestep, do_consolidate_graph):
+                                           timestep, do_consolidate_graph, fast_mode=True):
     """Wrapper for pypowsybl overflow graph builder with correct signature."""
     from expert_op4grid_recommender.pypowsybl_backend.overflow_analysis import build_overflow_graph_pypowsybl as _build
     return _build(env, obs_simu_defaut, lines_overloaded_ids_kept,
                   non_connected_reconnectable_lines, lines_non_reconnectable,
                   timestep, do_consolidate_graph=do_consolidate_graph, 
-                  use_dc=config.USE_DC_LOAD_FLOW)
+                  use_dc=config.USE_DC_LOAD_FLOW, param_options={"fast_mode": fast_mode})
 
 
 # =============================================================================
@@ -234,7 +234,8 @@ def run_analysis(analysis_date: Optional[datetime],
                  current_lines_defaut: List[str],
                  env_path: Optional[str] = None, 
                  env_name: Optional[str] = None,
-                 backend: Backend = Backend.GRID2OP) -> Dict[str, Any]:
+                 backend: Backend = Backend.GRID2OP,
+                 fast_mode: Optional[bool] = None) -> Dict[str, Any]:
     """
     Runs the expert system analysis for a given date, timestep, and contingency.
 
@@ -367,10 +368,16 @@ def run_analysis(analysis_date: Optional[datetime],
 
     # Simulate Contingency
     is_pypowsybl = backend == Backend.PYPOWSYBL
+    if fast_mode:
+        actual_fast_mode = True
+    else:
+        # Resolve fast_mode if not correctly specified, falling back to config for default
+        actual_fast_mode = config.PYPOWSYBL_FAST_MODE if fast_mode is None else fast_mode
+
     with Timer("Initial Contingency Simulation"):
         if is_pypowsybl:
             obs_simu_defaut, has_converged = simulate_contingency_pypowsybl(
-                env, obs, current_lines_defaut, act_reco_maintenance, current_timestep
+                env, obs, current_lines_defaut, act_reco_maintenance, current_timestep, fast_mode=actual_fast_mode
             )
         else:
             obs_simu_defaut, has_converged = simulate_contingency(
@@ -437,10 +444,16 @@ def run_analysis(analysis_date: Optional[datetime],
 
     # Build the overflow graph
     with Timer("Graph Building & DC Switch"):
-        has_converged, has_lost_load = check_simu_overloads(
-            obs, obs_simu_defaut, env.action_space, current_timestep, current_lines_defaut, lines_overloaded_ids_kept,
-            maintenance_to_reco_at_t
-        )
+        if is_pypowsybl:
+            has_converged, has_lost_load = check_simu_overloads(
+                obs, obs_simu_defaut, env.action_space, current_timestep, current_lines_defaut, lines_overloaded_ids_kept,
+                maintenance_to_reco_at_t, fast_mode=actual_fast_mode
+            )
+        else:
+            has_converged, has_lost_load = check_simu_overloads(
+                obs, obs_simu_defaut, env.action_space, current_timestep, current_lines_defaut, lines_overloaded_ids_kept,
+                maintenance_to_reco_at_t
+            )
 
         use_dc = config.USE_DC_LOAD_FLOW
         if not has_converged and not config.DO_FORCE_OVERLOAD_GRAPH_EVEN_IF_GRAPH_BROKEN_APART:
@@ -450,10 +463,16 @@ def run_analysis(analysis_date: Optional[datetime],
                 maintenance_to_reco_at_t
             )
 
-        df_of_g, overflow_sim, g_overflow, hubs, g_distribution_graph, node_name_mapping = build_overflow_graph(
-            env, obs_simu_defaut, lines_overloaded_ids_kept, non_connected_reconnectable_lines, lines_non_reconnectable,
-            current_timestep, do_consolidate_graph=config.DO_CONSOLIDATE_GRAPH
-        )
+        if is_pypowsybl:
+            df_of_g, overflow_sim, g_overflow, hubs, g_distribution_graph, node_name_mapping = build_overflow_graph(
+                env, obs_simu_defaut, lines_overloaded_ids_kept, non_connected_reconnectable_lines, lines_non_reconnectable,
+                current_timestep, do_consolidate_graph=config.DO_CONSOLIDATE_GRAPH, fast_mode=actual_fast_mode
+            )
+        else:
+            df_of_g, overflow_sim, g_overflow, hubs, g_distribution_graph, node_name_mapping = build_overflow_graph(
+                env, obs_simu_defaut, lines_overloaded_ids_kept, non_connected_reconnectable_lines, lines_non_reconnectable,
+                current_timestep, do_consolidate_graph=config.DO_CONSOLIDATE_GRAPH
+            )
 
     # Visualize graph (only if enabled in config)
     if config.DO_VISUALIZATION:
@@ -547,6 +566,11 @@ def run_analysis(analysis_date: Optional[datetime],
             create_default_action_func=create_default_action,
             obs_linecut=getattr(overflow_sim, 'obs_linecut', None)
         )
+        
+        # Monkey patch check_rho_reduction if using PyPowSybl so we can pass fast_mode through the discoverer indirectly
+        if is_pypowsybl:
+            original_check = discoverer._check_rho_reduction
+            discoverer._check_rho_reduction = lambda *args, **kwargs: original_check(*args, fast_mode=actual_fast_mode, **kwargs)
 
         prioritized_actions, action_scores = discoverer.discover_and_prioritize(
             n_action_max=config.N_PRIORITIZED_ACTIONS
@@ -593,7 +617,8 @@ def run_analysis(analysis_date: Optional[datetime],
                 obs_simu_action, _, _, info_action = obs_simu_defaut.simulate(
                     action,
                     time_step=current_timestep,
-                    keep_variant=True
+                    keep_variant=True,
+                    fast_mode=actual_fast_mode
                 )
             else:
                 # Standard backend behavior

--- a/expert_op4grid_recommender/pypowsybl_backend/network_manager.py
+++ b/expert_op4grid_recommender/pypowsybl_backend/network_manager.py
@@ -377,10 +377,11 @@ class NetworkManager:
                 else:
                     fast_exception = None
                     
-                # If we ran in fast mode and it didn't converge, retry in slow mode
-                if fast and (result_obj is None or result_obj.status != lf.ComponentStatus.CONVERGED):
-                    reason = fast_exception if result_obj is None else f"status: {result_obj.status}"
-                    print(f"Warning: Fast load flow failed or diverged ({reason}). Retrying in slow mode...")
+                # If we didn't converge, retry in slow mode
+                #if fast and (result_obj is None or result_obj.status != lf.ComponentStatus.CONVERGED):
+                if (result_obj is None or result_obj.status != lf.ComponentStatus.CONVERGED):
+                    #reason = fast_exception if result_obj is None else f"status: {result_obj.status}"
+                    #print(f"Warning: Load flow failed or diverged ({reason}). Retrying in slow mode...")
                     try:
                         results = self._run_ac_with_init_fallback(self.lf_parameters)
                         result_obj = results[0] if results else None

--- a/expert_op4grid_recommender/pypowsybl_backend/observation_timers.py
+++ b/expert_op4grid_recommender/pypowsybl_backend/observation_timers.py
@@ -10,7 +10,7 @@ import numpy as np
 import pandas as pd
 from typing import Dict, List, Tuple, Optional, Any, TYPE_CHECKING
 import pypowsybl.loadflow as lf
-# from expert_op4grid_recommender.utils.helpers import Timer
+from expert_op4grid_recommender.utils.helpers import Timer
 
 if TYPE_CHECKING:
     from .network_manager import NetworkManager
@@ -41,8 +41,7 @@ class PypowsyblObservation:
     def __init__(self, 
                  network_manager: 'NetworkManager',
                  action_space: 'ActionSpace',
-                 thermal_limits: Optional[Dict[str, float]] = None,
-                 variant_id: Optional[str] = None):
+                 thermal_limits: Optional[Dict[str, float]] = None):
         """
         Initialize observation from network state.
         
@@ -54,22 +53,6 @@ class PypowsyblObservation:
         self._network_manager = network_manager
         self._action_space = action_space
         self._thermal_limits = thermal_limits or network_manager.get_thermal_limits()
-        self._variant_id = variant_id
-
-        # Pre-calculate thermal limit arrays for efficient access
-        all_lines = self._network_manager.name_line
-        limit_or, limit_ex = self._network_manager.get_thermal_limits_arrays()
-        self._limit_or = pd.Series(limit_or, index=all_lines)
-        self._limit_ex = pd.Series(limit_ex, index=all_lines)
-        
-        # Apply overrides if any
-        if thermal_limits:
-            overrides = pd.Series(thermal_limits)
-            # Find lines that are in both all_lines and overrides
-            common = overrides.index.intersection(all_lines)
-            if not common.empty:
-                self._limit_or.update(overrides[common])
-                self._limit_ex.update(overrides[common])
         
         # Cache current state
         self._refresh_state()
@@ -79,116 +62,240 @@ class PypowsyblObservation:
         nm = self._network_manager
         net = nm.network
 
-        # Line and transformer information - fetch all at once including terminal buses
-        # Columns needed for: flows, status, angles, and bus assignments
-        line_cols = ['p1', 'q1', 'i1', 'p2', 'q2', 'i2', 'connected1', 'connected2', 'bus1_id', 'bus2_id']
-        # nm.get_line_flows doesn't yet support bus1/2_id easily without internal logic change
-        # Let's just do it here to ensure absolute control and minimal calls
-        lines_df = net.get_lines()[line_cols]
-        trafos_df = net.get_2_windings_transformers()[line_cols]
-        all_terminals_df = pd.concat([lines_df, trafos_df])
-        reindexed_flows = all_terminals_df.reindex(nm.name_line)
-
-        # Bus voltages and angles - fetch with voltage_level_id for bus assignments
-        bus_cols = ['v_mag', 'v_angle', 'voltage_level_id']
-        bus_data_df = net.get_buses()[bus_cols]
-        bus_df_aligned = bus_data_df.reindex(nm.name_sub)
-
-        # Cache line currents and powers as arrays for fast access
-        self._cache_line_arrays(reindexed_flows)
+        # Line information - get once and cache columns as dicts for fast lookup
+        self._line_flows = nm.get_line_flows()
+        self._line_flows_i1 = self._line_flows['i1'].to_dict()
+        self._line_flows_i2 = self._line_flows['i2'].to_dict()
+        self._line_flows_p1 = self._line_flows['p1'].to_dict()
+        self._line_flows_p2 = self._line_flows['p2'].to_dict()
+        self._line_flows_index_set = set(self._line_flows.index)
 
         # Compute rho (loading ratio)
         self._compute_rho()
 
-        # Line status - robustly convert to bool to avoid warnings
-        self._line_status = reindexed_flows['connected1'].fillna(True).astype(bool).values & \
-                            reindexed_flows['connected2'].fillna(True).astype(bool).values
+        # Line status
+        self._line_status = self._line_flows['connected'].values
 
         # Bus voltages and angles
-        self._v_mag = bus_df_aligned['v_mag'].values
-        self._v_angle = bus_df_aligned['v_angle'].values
+        bus_df = nm.get_bus_voltages()
+        self._v_mag = bus_df['v_mag'].values
+        self._v_angle = bus_df['v_angle'].values
 
-        # Get angles per line terminal - pass pre-fetched bus data
-        self._compute_line_angles(reindexed_flows, bus_data_df['v_angle'])
+        # Get angles per line terminal
+        self._compute_line_angles()
 
-        # Compute bus assignments for line terminals - pass pre-fetched data
-        self._compute_line_buses(reindexed_flows, bus_data_df)
+        # Compute bus assignments for line terminals
+        self._compute_line_buses()
 
-        # Load and generation - ensure alignment with name_load/name_gen
-        loads_df = net.get_loads()[['p', 'q']].reindex(nm.name_load)
-        gens_df = net.get_generators()[['p', 'q']].reindex(nm.name_gen)
-        self._load_p = loads_df['p'].fillna(0.0).values
-        self._load_q = loads_df['q'].fillna(0.0).values
-        self._gen_p = gens_df['p'].fillna(0.0).values
-        self._gen_q = gens_df['q'].fillna(0.0).values
+        # Load and generation - get once
+        loads_df = net.get_loads()
+        gens_df = net.get_generators()
+        self._load_p = loads_df['p'].values
+        self._load_q = loads_df['q'].values
+        self._gen_p = gens_df['p'].values
+        self._gen_q = gens_df['q'].values
+
+        # Cache line currents and powers as arrays for fast access
+        self._cache_line_arrays()
     
-    def _cache_line_arrays(self, reindexed_flows: pd.DataFrame):
-        """Cache line current and power arrays for fast property access. OPTIMIZED with reindex."""
-        # reindexed_flows is already aligned with nm.name_line
-        self._cached_i_or = reindexed_flows['i1'].fillna(0.0).values
-        self._cached_i_ex = reindexed_flows['i2'].fillna(0.0).values
-        self._cached_p_or = reindexed_flows['p1'].fillna(0.0).values
-        self._cached_p_ex = reindexed_flows['p2'].fillna(0.0).values
+    def _cache_line_arrays(self):
+        """Cache line current and power arrays for fast property access."""
+        nm = self._network_manager
+        n_line = nm.n_line
+        line_names = nm.name_line
+
+        # Pre-allocate arrays
+        self._cached_i_or = np.zeros(n_line)
+        self._cached_i_ex = np.zeros(n_line)
+        self._cached_p_or = np.zeros(n_line)
+        self._cached_p_ex = np.zeros(n_line)
+
+        # Fill arrays using cached dicts (much faster than df.loc in loop)
+        for i, line_id in enumerate(line_names):
+            if line_id in self._line_flows_index_set:
+                i1 = self._line_flows_i1.get(line_id, 0.0)
+                i2 = self._line_flows_i2.get(line_id, 0.0)
+                p1 = self._line_flows_p1.get(line_id, 0.0)
+                p2 = self._line_flows_p2.get(line_id, 0.0)
+
+                self._cached_i_or[i] = i1 if not np.isnan(i1) else 0.0
+                self._cached_i_ex[i] = i2 if not np.isnan(i2) else 0.0
+                self._cached_p_or[i] = p1 if not np.isnan(p1) else 0.0
+                self._cached_p_ex[i] = p2 if not np.isnan(p2) else 0.0
 
     def _compute_rho(self):
-        """Compute line loading ratios. OPTIMIZED with vectorized operations."""
+        """Compute line loading ratios. OPTIMIZED with cached dicts.
+
+        Uses i1 (side 1 current) for rho calculation since thermal limits
+        are defined for side 1 in pypowsybl convention.
+        """
         from expert_op4grid_recommender.config import MAX_RHO_BOTH_EXTREMITIES
-        
-        # Use pre-calculated thermal limits (including overrides)
-        limit_or = self._limit_or.values
-        limit_ex = self._limit_ex.values
+        nm = self._network_manager
+        n_line = nm.n_line
+        line_names = nm.name_line
 
-        # Avoid division by zero
-        limit_or = np.where(limit_or < 1e-6, 1e-6, limit_or)
-        limit_ex = np.where(limit_ex < 1e-6, 1e-6, limit_ex)
+        rho = np.zeros(n_line)
 
-        # Use cached current arrays (cached in _cache_line_arrays via _refresh_state)
-        i_or = np.abs(self._cached_i_or)
-        
-        if MAX_RHO_BOTH_EXTREMITIES:
-            i_ex = np.abs(self._cached_i_ex)
-            rho_or = i_or / limit_or
-            rho_ex = i_ex / limit_ex
-            self._rho = np.maximum(rho_or, rho_ex)
-        else:
-            self._rho = i_or / limit_or
+        # Use cached dict for fast lookup instead of df.loc
+        for i, line_id in enumerate(line_names):
+            if line_id in self._line_flows_index_set:
+                i1 = abs(self._line_flows_i1.get(line_id, 0.0))
+                i1 = i1 if not np.isnan(i1) else 0.0
+
+                thermal_limit = self._thermal_limits.get(line_id, 9999.0)
+                if isinstance(thermal_limit, (tuple, list)):
+                    limit_or = thermal_limit[0]
+                    limit_ex = thermal_limit[1]
+                else:
+                    limit_or = thermal_limit
+                    limit_ex = thermal_limit
+
+                if MAX_RHO_BOTH_EXTREMITIES:
+                    i2 = abs(self._line_flows_i2.get(line_id, 0.0))
+                    i2 = i2 if not np.isnan(i2) else 0.0
+                    rho_or = i1 / limit_or if limit_or > 0 else 0.0
+                    rho_ex = i2 / limit_ex if limit_ex > 0 else 0.0
+                    rho[i] = max(rho_or, rho_ex)
+                else:
+                    if limit_or > 0:
+                        rho[i] = i1 / limit_or
+
+        self._rho = rho
     
-    def _compute_line_angles(self, terminals: pd.DataFrame, bus_angles: pd.Series):
-        """Compute voltage angles at line terminals. OPTIMIZED with vectorization."""
-        # terminals is already reindexed to nm.name_line
-        
-        # Map angles to terminals
-        self._theta_or = terminals['bus1_id'].map(bus_angles).fillna(0.0).values / 360 * 2 * np.pi
-        self._theta_ex = terminals['bus2_id'].map(bus_angles).fillna(0.0).values / 360 * 2 * np.pi
-    
-    def _compute_line_buses(self, terminals: pd.DataFrame, buses_df: pd.DataFrame):
-        """Compute bus assignments for line terminals. OPTIMIZED with vectorization."""
-        # terminals is already reindexed to nm.name_line
-        
-        # 1. Pre-calculate local bus ranks (1, 2, ...) per Voltage Level
-        if not buses_df.empty:
-            # Sort by ID within each VL to ensure consistent 1, 2 numbering
-            buses_sorted = buses_df.sort_index()
-            # cumcount() gives 0, 1, ... so add 1 for bus numbers
-            buses_sorted['rank'] = buses_sorted.groupby('voltage_level_id').cumcount() + 1
-            bus_to_rank = buses_sorted['rank']
-        else:
-            bus_to_rank = pd.Series(dtype=int)
+    def _compute_line_angles(self):
+        """Compute voltage angles at line terminals. OPTIMIZED with dict lookups."""
+        nm = self._network_manager
+        net = nm.network
 
-        # 2. Map ranks and handle disconnections
-        # Default connected to True if missing (transformers often connected)
-        # Fix downcasting warnings by casting to bool after fillna
-        conn1 = terminals['connected1'].fillna(True).astype(bool).values
-        conn2 = terminals['connected2'].fillna(True).astype(bool).values
-        
-        # Map bus ranks
-        rank1 = terminals['bus1_id'].map(bus_to_rank).fillna(1).astype(int).values
-        rank2 = terminals['bus2_id'].map(bus_to_rank).fillna(1).astype(int).values
-        
-        # Disconnected terminals set to -1
-        # Also handle cases where bus_id is NaN but connected is True (should not happen in converged net)
-        self._line_or_bus = np.where(conn1 & terminals['bus1_id'].notna(), rank1, -1)
-        self._line_ex_bus = np.where(conn2 & terminals['bus2_id'].notna(), rank2, -1)
+        n_line = nm.n_line
+        self._theta_or = np.zeros(n_line)
+        self._theta_ex = np.zeros(n_line)
+
+        # Get bus information - extract as dicts for fast lookup
+        lines_df = net.get_lines()
+        trafos_df = net.get_2_windings_transformers()
+        buses_df = net.get_buses()
+
+        # Pre-extract columns as dicts
+        lines_bus1 = lines_df['bus1_id'].to_dict() if len(lines_df) > 0 else {}
+        lines_bus2 = lines_df['bus2_id'].to_dict() if len(lines_df) > 0 else {}
+        trafos_bus1 = trafos_df['bus1_id'].to_dict() if len(trafos_df) > 0 else {}
+        trafos_bus2 = trafos_df['bus2_id'].to_dict() if len(trafos_df) > 0 else {}
+        bus_angles = buses_df['v_angle'].to_dict() if len(buses_df) > 0 else {}
+
+        # Use cached sets from NetworkManager
+        lines_set = nm._lines_set
+        trafos_set = nm._trafos_set
+
+        for i, line_id in enumerate(nm.name_line):
+            try:
+                if line_id in lines_set:
+                    bus1_id = lines_bus1.get(line_id)
+                    bus2_id = lines_bus2.get(line_id)
+                elif line_id in trafos_set:
+                    bus1_id = trafos_bus1.get(line_id)
+                    bus2_id = trafos_bus2.get(line_id)
+                else:
+                    continue
+
+                if pd.notna(bus1_id) and bus1_id in bus_angles:
+                    self._theta_or[i] = bus_angles[bus1_id] / 360 * 2 * np.pi
+                if pd.notna(bus2_id) and bus2_id in bus_angles:
+                    self._theta_ex[i] = bus_angles[bus2_id] / 360 * 2 * np.pi
+            except (KeyError, TypeError):
+                pass
+    
+    def _compute_line_buses(self):
+        """
+        Compute bus assignments for line terminals. OPTIMIZED with dict lookups.
+
+        In grid2op, line_or_bus and line_ex_bus indicate which local bus (1 or 2)
+        each line terminal is connected to within its substation.
+        -1 means disconnected.
+
+        In pypowsybl with bus/breaker topology, we map the bus_id to a local
+        bus number within the voltage level (substation).
+        """
+        nm = self._network_manager
+        net = nm.network
+
+        n_line = nm.n_line
+        self._line_or_bus = np.ones(n_line, dtype=int)  # Default to bus 1
+        self._line_ex_bus = np.ones(n_line, dtype=int)  # Default to bus 1
+
+        # Get line and transformer data - extract columns as dicts
+        lines_df = net.get_lines()
+        trafos_df = net.get_2_windings_transformers()
+
+        lines_bus1 = lines_df['bus1_id'].to_dict() if len(lines_df) > 0 else {}
+        lines_bus2 = lines_df['bus2_id'].to_dict() if len(lines_df) > 0 else {}
+        lines_conn1 = lines_df['connected1'].to_dict() if 'connected1' in lines_df.columns else {}
+        lines_conn2 = lines_df['connected2'].to_dict() if 'connected2' in lines_df.columns else {}
+
+        trafos_bus1 = trafos_df['bus1_id'].to_dict() if len(trafos_df) > 0 else {}
+        trafos_bus2 = trafos_df['bus2_id'].to_dict() if len(trafos_df) > 0 else {}
+        trafos_conn1 = trafos_df['connected1'].to_dict() if 'connected1' in trafos_df.columns else {}
+        trafos_conn2 = trafos_df['connected2'].to_dict() if 'connected2' in trafos_df.columns else {}
+
+        # Build a mapping of voltage_level -> list of bus_ids
+        buses_df = net.get_buses()
+        bus_to_vl = buses_df['voltage_level_id'].to_dict() if len(buses_df) > 0 else {}
+        buses_set = set(buses_df.index)
+
+        vl_to_buses = {}
+        for bus_id, vl_id in bus_to_vl.items():
+            if vl_id not in vl_to_buses:
+                vl_to_buses[vl_id] = []
+            vl_to_buses[vl_id].append(bus_id)
+
+        # Sort buses within each voltage level for consistent numbering
+        # and build index lookup for O(1) access
+        vl_bus_to_local = {}
+        for vl_id, bus_list in vl_to_buses.items():
+            sorted_buses = sorted(bus_list)
+            vl_to_buses[vl_id] = sorted_buses
+            for idx, bus_id in enumerate(sorted_buses):
+                vl_bus_to_local[(vl_id, bus_id)] = idx + 1
+
+        # Use cached sets from NetworkManager
+        lines_set = nm._lines_set
+        trafos_set = nm._trafos_set
+
+        for i, line_id in enumerate(nm.name_line):
+            try:
+                # Get bus IDs for this line
+                if line_id in lines_set:
+                    bus1_id = lines_bus1.get(line_id)
+                    bus2_id = lines_bus2.get(line_id)
+                    connected1 = lines_conn1.get(line_id, True)
+                    connected2 = lines_conn2.get(line_id, True)
+                elif line_id in trafos_set:
+                    bus1_id = trafos_bus1.get(line_id)
+                    bus2_id = trafos_bus2.get(line_id)
+                    connected1 = trafos_conn1.get(line_id, True)
+                    connected2 = trafos_conn2.get(line_id, True)
+                else:
+                    continue
+
+                # Determine local bus number for origin (bus1)
+                if pd.isna(bus1_id) or (isinstance(connected1, bool) and not connected1):
+                    self._line_or_bus[i] = -1  # Disconnected
+                elif bus1_id in buses_set:
+                    vl_id = bus_to_vl.get(bus1_id, '')
+                    local_bus = vl_bus_to_local.get((vl_id, bus1_id), 1)
+                    self._line_or_bus[i] = local_bus
+
+                # Determine local bus number for extremity (bus2)
+                if pd.isna(bus2_id) or (isinstance(connected2, bool) and not connected2):
+                    self._line_ex_bus[i] = -1  # Disconnected
+                elif bus2_id in buses_set:
+                    vl_id = bus_to_vl.get(bus2_id, '')
+                    local_bus = vl_bus_to_local.get((vl_id, bus2_id), 1)
+                    self._line_ex_bus[i] = local_bus
+
+            except (KeyError, TypeError):
+                # Default to bus 1 if we can't determine
+                pass
     
     # ========== Grid2op-compatible properties ==========
     
@@ -638,41 +745,45 @@ class PypowsyblObservation:
         info = {"exception": []}
 
         try:
-            # Create a new variant branching from the current observation's variant
-            # (or from the base variant if self._variant_id is None)
-            nm.create_variant(variant_id, from_variant=self._variant_id)
-            nm.set_working_variant(variant_id)
+            with Timer("Action simulation"):
+                with Timer("Variant creation"):
+                    # Create temporary variant
+                    nm.create_variant(variant_id)
+                    nm.set_working_variant(variant_id)
 
             # Apply action
-            action.apply(nm)
+            with Timer("Apply action"):
+                action.apply(nm)
 
-            # Run load flow in fast mode (disabled voltage control) for variants if requested
-            result = nm.run_load_flow(fast=fast_mode)
+            # Run load flow
+            with Timer("Run load flow"):
+                result = nm.run_load_flow(fast=fast_mode)
 
             if result is None or result.status != lf.ComponentStatus.CONVERGED:
                 info["exception"].append(
                     Exception(f"Load flow did not converge: {result.status if result else 'No result'}")
                 )
                 # Return observation with NaN values
-                obs_simu = PypowsyblObservation(nm, self._action_space, self._thermal_limits, 
-                                               variant_id=variant_id if keep_variant else None)
-                return obs_simu, 0.0, True, info
+                with Timer("Observation creation (failed)"):
+                    obs_simu = PypowsyblObservation(nm, self._action_space, self._thermal_limits)
+                    if keep_variant:
+                        obs_simu._variant_id = variant_id
+                    return obs_simu, 0.0, True, info
 
             # Create observation from simulated state
-            obs_simu = PypowsyblObservation(nm, self._action_space, self._thermal_limits,
-                                           variant_id=variant_id if keep_variant else None)
+            with Timer("Observation creation (success)"):
+                obs_simu = PypowsyblObservation(nm, self._action_space, self._thermal_limits)
+                if keep_variant:
+                    obs_simu._variant_id = variant_id
 
             return obs_simu, 0.0, False, info
 
         except Exception as e:
-            print(f"Warning: Action simulation failed for action {action}: {e}")
             info["exception"].append(e)
             # Try to create an observation anyway
             try:
-                obs_simu = PypowsyblObservation(nm, self._action_space, self._thermal_limits,
-                                               variant_id=variant_id if keep_variant else None)
-            except Exception as inner_e:
-                print(f"Error: Failed to create fallback observation: {inner_e}")
+                obs_simu = PypowsyblObservation(nm, self._action_space, self._thermal_limits)
+            except:
                 obs_simu = self  # Return self if we can't create new obs
             return obs_simu, 0.0, True, info
 

--- a/expert_op4grid_recommender/pypowsybl_backend/overflow_analysis.py
+++ b/expert_op4grid_recommender/pypowsybl_backend/overflow_analysis.py
@@ -36,17 +36,19 @@ class OverflowSimulator:
     Uses pypowsybl's load flow (AC or DC) to compute flow redistribution 
     after line outages.
     
-    This replaces alphaDeesp's Grid2opSimulation for overflow graph building.
+        This replaces alphaDeesp's Grid2opSimulation for overflow graph building.
     
     Attributes:
         use_dc: If True, uses DC load flow. If False, uses AC load flow.
+        fast_mode: If True, uses fast mode for load flow (no voltage control).
     """
     
     def __init__(self, 
                  network_manager: 'NetworkManager',
                  obs: 'PypowsyblObservation',
                  use_dc: bool = False,
-                 param_options: Optional[Dict] = None):
+                 param_options: Optional[Dict] = None,
+                 fast_mode: bool = True):
         """
         Initialize the overflow simulator.
         
@@ -55,12 +57,14 @@ class OverflowSimulator:
             obs: Current observation (after initial contingency)
             use_dc: If True, use DC load flow. If False, use AC (default).
             param_options: Configuration parameters (thresholds, etc.)
+            fast_mode: If True, uses fast mode for load flow.
         """
         self._nm = network_manager
         self._obs = obs
         self._net = network_manager.network
         self._use_dc = use_dc
         self._param_options = param_options or {}
+        self._fast_mode = fast_mode
         
         # Get current line flows FROM THE OBSERVATION (not network)
         # This ensures we have the correct base flows even if the observation
@@ -76,9 +80,7 @@ class OverflowSimulator:
     
     def _run_load_flow(self) -> lf.ComponentResult:
         """Run load flow with configured mode (AC or DC) and fast optimization."""
-        from expert_op4grid_recommender import config
-        fast_mode = getattr(config, 'PYPOWSYBL_FAST_MODE', True)
-        return self._nm.run_load_flow(dc=self._use_dc, fast=fast_mode)
+        return self._nm.run_load_flow(dc=self._use_dc, fast=self._fast_mode)
     
     def _get_line_flows(self) -> Dict[str, float]:
         """Get active power flows for all lines (MW at terminal 1)."""
@@ -677,6 +679,8 @@ def build_overflow_graph_pypowsybl(env: 'SimulationEnvironment',
     from alphaDeesp.core.graphsAndPaths import OverFlowGraph, Structured_Overload_Distribution_Graph
     
     params = param_options or PARAM_OPTIONS_EXPERT_OP
+    # Keep the fast_mode extraction flexible
+    fast_mode = params.get("fast_mode", True) if isinstance(params, dict) else True
     
     # Create alphaDeesp-compatible adapter (replaces Grid2opSimulation)
     overflow_sim = AlphaDeespAdapter(
@@ -688,7 +692,8 @@ def build_overflow_graph_pypowsybl(env: 'SimulationEnvironment',
         ltc=overloaded_line_ids,
         plot=False,
         simu_step=timestep,
-        use_dc=use_dc
+        use_dc=use_dc,
+        fast_mode=fast_mode
     )
     
     # Get flow changes DataFrame
@@ -830,7 +835,8 @@ class AlphaDeespAdapter:
                  ltc: List[int] = None,
                  plot: bool = False,
                  simu_step: int = 0,
-                 use_dc: bool = False):
+                 use_dc: bool = False,
+                 fast_mode: bool = True):
         """
         Initialize adapter with alphaDeesp-compatible interface.
         
@@ -862,7 +868,8 @@ class AlphaDeespAdapter:
             network_manager=obs._network_manager,
             obs=obs,
             use_dc=use_dc,
-            param_options=param_options
+            param_options=param_options,
+            fast_mode=fast_mode
         )
         
         # Build topology info

--- a/expert_op4grid_recommender/utils/simulation_pypowsybl.py
+++ b/expert_op4grid_recommender/utils/simulation_pypowsybl.py
@@ -34,7 +34,7 @@ def create_default_action(action_space: Callable, defauts: List[str]) -> Any:
 
 
 def simulate_contingency(env: Any, obs: Any, lines_defaut: List[str], 
-                         act_reco_maintenance: Any, timestep: int) -> Tuple[Any, bool]:
+                         act_reco_maintenance: Any, timestep: int, fast_mode: bool = True) -> Tuple[Any, bool]:
     """
     Simulates the application of an initial N-1 contingency and any maintenance reconnections.
 
@@ -65,7 +65,8 @@ def simulate_contingency(env: Any, obs: Any, lines_defaut: List[str],
     obs_simu, _, _, info = obs.simulate(
         act_deco_defaut + act_reco_maintenance, 
         time_step=timestep,
-        keep_variant=True
+        keep_variant=True,
+        fast_mode=fast_mode
     )
 
     # Check if the simulation raised any exceptions
@@ -81,7 +82,8 @@ def check_rho_reduction_with_baseline(obs: Any, timestep: int, act_defaut: Any, 
                                        baseline_rho: np.ndarray,
                                        lines_we_care_about: Optional[np.ndarray] = None,
                                        rho_tolerance: float = 0.01,
-                                       verbose: bool = True) -> Tuple[bool, Optional[Any]]:
+                                       verbose: bool = True,
+                                       fast_mode: bool = True) -> Tuple[bool, Optional[Any]]:
     """
     Checks if applying a candidate action reduces line loadings (rho) below a pre-computed baseline.
 
@@ -110,7 +112,7 @@ def check_rho_reduction_with_baseline(obs: Any, timestep: int, act_defaut: Any, 
     # This automatically includes the contingency and maintenance from 'obs'
     # without double-applying them.
     obs_simu_action, _, _, info_action = obs.simulate(
-        action, time_step=timestep
+        action, time_step=timestep, fast_mode=fast_mode
     )
 
     if info_action["exception"]:
@@ -152,7 +154,7 @@ def check_rho_reduction_with_baseline(obs: Any, timestep: int, act_defaut: Any, 
 
 def compute_baseline_simulation(obs: Any, timestep: int, act_defaut: Any,
                                  act_reco_maintenance: Any,
-                                 overload_ids: List[int]) -> Tuple[Optional[np.ndarray], Optional[Any]]:
+                                 overload_ids: List[int], fast_mode=True) -> Tuple[Optional[np.ndarray], Optional[Any]]:
     """
     Computes the baseline simulation once for use with multiple candidate actions.
 
@@ -172,7 +174,7 @@ def compute_baseline_simulation(obs: Any, timestep: int, act_defaut: Any,
     # Simulate the baseline state (contingency + maintenance)
     # We branch from the base observation 'obs'
     obs_baseline, _, _, info_baseline = obs.simulate(
-        act_defaut + act_reco_maintenance, time_step=timestep, keep_variant=True
+        act_defaut + act_reco_maintenance, time_step=timestep, keep_variant=True, fast_mode=fast_mode
     )
 
     if info_baseline["exception"]:
@@ -186,7 +188,7 @@ def compute_baseline_simulation(obs: Any, timestep: int, act_defaut: Any,
 def check_rho_reduction(obs: Any, timestep: int, act_defaut: Any, action: Any,
                         overload_ids: List[int], act_reco_maintenance: Any,
                         lines_we_care_about: Optional[np.ndarray] = None,
-                        rho_tolerance: float = 0.01) -> Tuple[bool, Optional[Any]]:
+                        rho_tolerance: float = 0.01, fast_mode: bool = True) -> Tuple[bool, Optional[Any]]:
     """
     Checks if applying a candidate action reduces line loadings (rho) below a baseline.
 
@@ -218,7 +220,7 @@ def check_rho_reduction(obs: Any, timestep: int, act_defaut: Any, action: Any,
     """
     # Compute baseline
     baseline_rho, obs_baseline = compute_baseline_simulation(
-        obs, timestep, act_defaut, act_reco_maintenance, overload_ids
+        obs, timestep, act_defaut, act_reco_maintenance, overload_ids, fast_mode=fast_mode
     )
 
     if baseline_rho is None:
@@ -227,13 +229,13 @@ def check_rho_reduction(obs: Any, timestep: int, act_defaut: Any, action: Any,
     # Use the optimized function
     return check_rho_reduction_with_baseline(
         obs, timestep, act_defaut, action, overload_ids, act_reco_maintenance,
-        baseline_rho, lines_we_care_about, rho_tolerance
+        baseline_rho, lines_we_care_about, rho_tolerance, fast_mode=fast_mode
     )
 
 
 def check_simu_overloads(obs: Any, obs_defaut: Any, action_space: Callable, timestep: int,
                          lines_defaut: List[str], lines_overloaded_ids: List[int],
-                         lines_reco_maintenance: List[str]) -> Tuple[bool, bool]:
+                         lines_reco_maintenance: List[str], fast_mode: bool = True) -> Tuple[bool, bool]:
     """
     Simulates disconnecting all specified overloaded lines simultaneously.
 
@@ -271,7 +273,7 @@ def check_simu_overloads(obs: Any, obs_defaut: Any, action_space: Callable, time
     # Simulate the combined action
     obs_simu, _, _, info = obs.simulate(
         act_deco_overloads + act_deco_defaut + act_reco_maintenance_obj, 
-        time_step=timestep
+        time_step=timestep, fast_mode=fast_mode
     )
 
     # Check for simulation failure

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -73,6 +73,7 @@ DO_VISUALIZATION = False  # Skip visualization in tests for faster execution
 MAX_RHO_BOTH_EXTREMITIES = False  # only possible for now with pypowsybl backend
 MONITORING_FACTOR_THERMAL_LIMITS = 0.95  # factor applied to permanent thermal limits when loading from operational limits
 PRE_EXISTING_OVERLOAD_WORSENING_THRESHOLD = 0.02  # 2% – pre-existing overloads excluded from analysis unless current increased by this fraction
+PYPOWSYBL_FAST_MODE=False
 
 # Minimum number of prioritized actions per type
 MIN_LINE_RECONNECTIONS = 0


### PR DESCRIPTION
## Goal
Propagate the 'fast_mode' parameter from the top-level 'run_analysis' function down to all pypowsybl-based simulation components. This ensures that the 'PYPOWSYBL_FAST_MODE' setting in 'config.py' is respected throughout the analysis without submodules needing to import the config directly.

## Proposed Changes
### Core Analysis Logic
- main.py: Added 'fast_mode' parameter to 'run_analysis' and all pypowsybl wrapper functions. It now intelligently resolves the setting and passes it down.
- utils/simulation_pypowsybl.py: Updated contingency simulation and rho reduction checks to accept and propagate the 'fast_mode' flag.

### Pypowsybl Backend
- pypowsybl_backend/observation.py: The 'simulate' method now accepts 'fast_mode' and passes it to the 'NetworkManager'.
- pypowsybl_backend/overflow_analysis.py: Removed direct 'config' import. 'OverflowSimulator' and 'AlphaDeespAdapter' now take 'fast_mode' as a constructor argument. Updated 'build_overflow_graph_pypowsybl' to pass the parameter.

### Bug Fix
- Fixed an 'AttributeError' in 'main.py' where '_check_rho_reduction' was incorrectly accessed as 'check_rho_reduction_func' during monkey-patching of the 'ActionDiscoverer'.
