### PR TITLE
Add pypowsybl format action builder with deduplication

### DIFF
--- a/expert_op4grid_recommender/action_evaluation/classifier.py
+++ b/expert_op4grid_recommender/action_evaluation/classifier.py
@@ -24,7 +24,8 @@ class ActionClassifier:
     analyzing a Grid2Op Action object directly.
     """
 
-    def __init__(self, grid2op_action_space: Optional[Callable] = None):
+    def __init__(self, grid2op_action_space: Optional[Callable] = None,
+                 branch_names=None, load_names=None):
         """
         Initializes the ActionClassifier.
 
@@ -32,8 +33,54 @@ class ActionClassifier:
             grid2op_action_space (Optional[Callable]): A callable (like env.action_space)
                 needed if classifying actions directly from Grid2Op objects
                 (when using `identify_action_type` with `by_description=False`).
+            branch_names: Collection of branch (line/transformer) IDs in the network.
+                When provided alongside a pypowsybl action dict (with a ``switches``
+                field), asset names extracted from switch IDs are matched against this
+                set to infer ``has_line`` without triggering lazy content computation.
+            load_names: Collection of load IDs in the network, used analogously to
+                ``branch_names`` for inferring ``has_load``.
         """
         self._action_space = grid2op_action_space
+        self._branch_names: Optional[frozenset] = frozenset(branch_names) if branch_names is not None else None
+        self._load_names: Optional[frozenset] = frozenset(load_names) if load_names is not None else None
+
+    def _infer_has_line_load(self, actions_desc: Dict[str, Any]) -> Tuple[bool, bool]:
+        """Return (has_line, has_load) without triggering lazy content computation.
+
+        For pypowsybl-format actions (those with a ``switches`` field) and when
+        ``branch_names``/``load_names`` were supplied at construction time, asset
+        names are extracted from switch IDs using the naming convention
+        ``"{VoltageLevel}_{AssetName} {SuffixXX}_OC"`` and matched against the
+        pre-built frozensets.  This avoids lazy-loading ``content.set_bus`` for
+        every action in the dictionary.
+
+        Falls back to reading ``content.set_bus`` (the grid2op path, which may
+        trigger lazy computation) when switches or name sets are unavailable.
+        """
+        switches = actions_desc.get("switches")
+        if switches is not None and self._branch_names is not None:
+            has_line, has_load = False, False
+            for switch_id in switches:
+                # Switch ID format: "{VoltageLevel}_{AssetName} {SuffixXX}_OC"
+                try:
+                    asset_name = switch_id.split("_", 1)[1].rsplit(" ", 1)[0]
+                except IndexError:
+                    continue
+                if not has_line and asset_name in self._branch_names:
+                    has_line = True
+                if not has_load and self._load_names and asset_name in self._load_names:
+                    has_load = True
+                if has_line and has_load:
+                    break
+            return has_line, has_load
+
+        # grid2op path: use set_bus (may trigger lazy computation for LazyActionDict)
+        content = actions_desc.get("content", {})
+        dict_action = content.get("set_bus", {})
+        has_load = "loads_id" in dict_action and len(dict_action["loads_id"]) != 0
+        has_line = (("lines_or_id" in dict_action and len(dict_action["lines_or_id"]) != 0) or
+                    ("lines_ex_id" in dict_action and len(dict_action["lines_ex_id"]) != 0))
+        return has_line, has_load
 
     def _is_nodale_grid2op_action(self, act: Any) -> Tuple[bool, List[int], List[bool]]:
         """
@@ -199,16 +246,12 @@ class ActionClassifier:
 
         if by_description:
             try:
-                content = actions_desc.get("content", {})
-                dict_action = content.get("set_bus", {})
-                has_load = "loads_id" in dict_action and len(dict_action["loads_id"]) != 0
-                has_line = (("lines_or_id" in dict_action and len(dict_action["lines_or_id"]) != 0) or
-                            ("lines_ex_id" in dict_action and len(dict_action["lines_ex_id"]) != 0))
                 description = actions_desc.get("description_unitaire", actions_desc.get("description", ""))
 
-                if ("COUPL" in description or "TRO." in description):
+                if "COUPL" in description or "TRO." in description:
                     action_type = "open_coupling" if "Ouverture" in description else "close_coupling"
                 elif "Ouverture" in description or "deconnection" in description:
+                    has_line, has_load = self._infer_has_line_load(actions_desc)
                     if has_load and has_line:
                         action_type = "open_line_load"
                     elif has_line:
@@ -216,6 +259,7 @@ class ActionClassifier:
                     elif has_load:
                         action_type = "open_load"
                 elif "Fermeture" in description or "reconnection" in description:
+                    has_line, has_load = self._infer_has_line_load(actions_desc)
                     if has_load and has_line:
                         action_type = "close_line_load"
                     elif has_line:
@@ -223,13 +267,9 @@ class ActionClassifier:
                     elif has_load:
                         action_type = "close_load"
 
-            except KeyError as e:
+            except (KeyError, AttributeError) as e:
                 print(
-                    f"Warning: Missing expected key for description-based classification: {e}. Action: {actions_desc.get('description_unitaire', 'N/A')}")
-                action_type = "unknown"  # Fallback if structure is wrong
-            except AttributeError as e:  # Handle cases where content['set_bus'] might not be a dict
-                print(
-                    f"Warning: Invalid structure in action description content: {e}. Action: {actions_desc.get('description_unitaire', 'N/A')}")
+                    f"Warning: Could not classify action by description: {e}. Action: {actions_desc.get('description_unitaire', 'N/A')}")
                 action_type = "unknown"
 
         else:

--- a/expert_op4grid_recommender/main.py
+++ b/expert_op4grid_recommender/main.py
@@ -315,7 +315,15 @@ def run_analysis_step1(analysis_date: Optional[datetime],
             dict_action = enrich_actions_lazy(dict_action, n_grid)
 
     # --- Instantiate Classifier ---
-    classifier = ActionClassifier(grid2op_action_space=env.action_space)
+    if backend == Backend.PYPOWSYBL:
+        # Build name sets once so identify_action_type can infer has_line/has_load
+        # from switch IDs without triggering lazy content computation.
+        _branch_names = set(n_grid.get_lines().index) | set(n_grid.get_2_windings_transformers().index)
+        _load_names = set(n_grid.get_loads(attributes=[]).index)
+        classifier = ActionClassifier(grid2op_action_space=env.action_space,
+                                      branch_names=_branch_names, load_names=_load_names)
+    else:
+        classifier = ActionClassifier(grid2op_action_space=env.action_space)
 
     if is_bare_env:
         act_reco_maintenance = env.action_space({})

--- a/expert_op4grid_recommender/main.py
+++ b/expert_op4grid_recommender/main.py
@@ -799,6 +799,17 @@ def main():
         help="Voltage filter threshold for REPAS actions (default: 300)"
     )
     parser.add_argument(
+        "--pypowsybl-format",
+        action='store_true',
+        help=(
+            "When used with --rebuild-actions and an empty action file (from scratch), "
+            "outputs the action dictionary in pypowsybl format: switch-based entries with "
+            "description, description_unitaire, VoltageLevelId and switches fields "
+            "(no Grid2Op set_bus content). Duplicate actions sharing identical switch "
+            "states are deduplicated; removed duplicates are listed in 'other_action_ids'."
+        )
+    )
+    parser.add_argument(
         "--ignore-lines-monitoring",
         action='store_true',
         help="If set, ignores the lignes_a_monitorer.csv file and monitors all lines."
@@ -848,7 +859,8 @@ def main():
                 dict_action = run_rebuild_actions(n_grid, do_from_scratch, args.repas_file,
                                                    dict_action_to_filter_on=dict_action,
                                                    voltage_filter_threshold=args.voltage_threshold,
-                                                   output_file_base_name="reduced_model_actions")
+                                                   output_file_base_name="reduced_model_actions",
+                                                   pypowsybl_format=args.pypowsybl_format)
 
                 print("Action rebuilding process complete. Stopping analysis as requested.")
                 return  # EXIT EARLY

--- a/expert_op4grid_recommender/utils/action_rebuilder.py
+++ b/expert_op4grid_recommender/utils/action_rebuilder.py
@@ -445,8 +445,8 @@ def run_rebuild_actions(n_grid, do_from_scratch, repas_file_path, dict_action_to
                 new_dict_actions = rebuild_action_dict_for_snapshot(n_grid, all_actions, dict_action_to_filter_on)
 
         # Save to file
-        with open(output_file_path, "w") as json_file:
-            json.dump(new_dict_actions, json_file, indent=4)
+        with open(output_file_path, "w", encoding="utf-8") as json_file:
+            json.dump(new_dict_actions, json_file, indent=4, ensure_ascii=False)
 
         print(f"Successfully rebuilt actions. Saved to: {output_file_path}")
         return new_dict_actions

--- a/expert_op4grid_recommender/utils/action_rebuilder.py
+++ b/expert_op4grid_recommender/utils/action_rebuilder.py
@@ -23,7 +23,8 @@ from expert_op4grid_recommender.utils.helpers import Timer
 from expert_op4grid_recommender.utils import repas
 from expert_op4grid_recommender.utils.conversion_actions_repas import (
     convert_repas_actions_to_grid2op_actions,
-    create_dict_disco_reco_lines_disco
+    create_dict_disco_reco_lines_disco,
+    get_all_switch_descriptions,
 )
 
 def make_description_unitaire(switches_by_voltage_level):
@@ -360,7 +361,7 @@ def build_action_dict_pypowsybl_format_from_scratch(n_grid, all_actions, add_rec
 
             result[action_key] = {
                 "description": action._description,
-                "description_unitaire": action._description,
+                "description_unitaire": get_all_switch_descriptions(action._switches_by_voltage_level),
                 "VoltageLevelId": voltage_level,
                 "switches": switches_flat,
             }

--- a/expert_op4grid_recommender/utils/action_rebuilder.py
+++ b/expert_op4grid_recommender/utils/action_rebuilder.py
@@ -17,6 +17,7 @@ from REPAS format to Grid2Op format based on network grid snapshots.
 import copy
 import json
 import os
+from collections import defaultdict
 from expert_op4grid_recommender.utils.helpers import Timer
 
 from expert_op4grid_recommender.utils import repas
@@ -219,8 +220,165 @@ def rebuild_action_dict_for_snapshot(n_grid, all_actions, dict_action):
     return new_dict_actions
 
 
+def _create_dict_disco_reco_pypowsybl_format(n_grid, filter_voltage_levels=None):
+    """
+    Create disconnection/reconnection entries for lines in pypowsybl format.
+
+    Unlike create_dict_disco_reco_lines_disco, these entries contain only
+    description and description_unitaire (no Grid2Op set_bus content).
+    Lines whose both extremity voltage levels are in filter_voltage_levels are excluded.
+
+    Parameters
+    ----------
+    n_grid : pypowsybl.network.Network
+        The network grid object.
+    filter_voltage_levels : list, optional
+        Voltage levels to exclude (default: [400, 24., 15., 20., 33., 10.]).
+
+    Returns
+    -------
+    dict
+        Disco/reco entries keyed by "disco_{line}" and "reco_{line}".
+    """
+    if filter_voltage_levels is None:
+        filter_voltage_levels = [400, 24., 15., 20., 33., 10.]
+
+    result = {}
+    branches_df = n_grid.get_branches()[["voltage_level1_id", "voltage_level2_id"]]
+    vl_df = n_grid.get_voltage_levels()
+
+    branches_df["voltage_level1"] = vl_df.loc[branches_df["voltage_level1_id"], "nominal_v"].values
+    branches_df["voltage_level2"] = vl_df.loc[branches_df["voltage_level2_id"], "nominal_v"].values
+
+    filter_set = set(filter_voltage_levels)
+    mask = (~branches_df["voltage_level1"].isin(filter_set)) & \
+           (~branches_df["voltage_level2"].isin(filter_set))
+
+    for line in branches_df[mask].index:
+        result[f"disco_{line}"] = {
+            "description": f"Disconnection of line/transformer '{line}'",
+            "description_unitaire": f"Ouverture de la ligne '{line}'"
+        }
+        result[f"reco_{line}"] = {
+            "description": f"Reconnection of line/transformer '{line}'",
+            "description_unitaire": f"Fermeture de la ligne '{line}'"
+        }
+
+    return result
+
+
+def deduplicate_actions_by_switches(dict_actions):
+    """
+    Deduplicate actions that have identical switch states.
+
+    Actions without a 'switches' field (e.g., disco/reco line actions) are kept
+    as-is. For each group of actions sharing the same switch fingerprint, the first
+    encountered action is kept as the reference. Its 'other_action_ids' field is
+    populated with the IDs of the removed duplicates.
+
+    Parameters
+    ----------
+    dict_actions : dict
+        Dictionary of actions keyed by action ID.
+
+    Returns
+    -------
+    dict
+        Deduplicated dictionary. Reference actions may have an 'other_action_ids'
+        field listing the IDs of removed duplicates.
+    """
+    # First pass: group action IDs by switch fingerprint (preserving insertion order)
+    fingerprint_to_ids = defaultdict(list)
+    for action_id, action in dict_actions.items():
+        if "switches" in action and action["switches"]:
+            fingerprint = frozenset(action["switches"].items())
+            fingerprint_to_ids[fingerprint].append(action_id)
+
+    # Determine reference vs duplicate IDs
+    reference_ids = set()
+    duplicates_for_reference = {}  # reference_id -> [duplicate_ids]
+    for fingerprint, ids in fingerprint_to_ids.items():
+        ref_id = ids[0]
+        reference_ids.add(ref_id)
+        if len(ids) > 1:
+            duplicates_for_reference[ref_id] = ids[1:]
+
+    # Second pass: build result, skipping duplicates
+    result = {}
+    for action_id, action in dict_actions.items():
+        if "switches" not in action or not action["switches"]:
+            result[action_id] = action
+        elif action_id in reference_ids:
+            new_action = dict(action)
+            if action_id in duplicates_for_reference:
+                new_action["other_action_ids"] = duplicates_for_reference[action_id]
+            result[action_id] = new_action
+        # else: duplicate — omitted, already listed in reference's other_action_ids
+
+    return result
+
+
+def build_action_dict_pypowsybl_format_from_scratch(n_grid, all_actions, add_reco_disco_actions=False,
+                                                     filter_voltage_levels=None):
+    """
+    Builds the action dictionary in pypowsybl format (switch-based) from scratch.
+
+    Unlike build_action_dict_for_snapshot_from_scratch, this function does NOT
+    compute Grid2Op topology. Each entry contains only:
+    description, description_unitaire, VoltageLevelId, switches.
+
+    Duplicate actions sharing the same switch states are deduplicated: the first
+    occurrence is kept as the reference and lists removed duplicates in
+    'other_action_ids'.
+
+    Parameters
+    ----------
+    n_grid : pypowsybl.network.Network
+        The network grid object (required when add_reco_disco_actions is True).
+    all_actions : list
+        List of REPAS action objects.
+    add_reco_disco_actions : bool, optional
+        Whether to add line disconnection/reconnection entries (default: False).
+    filter_voltage_levels : list, optional
+        Voltage levels to exclude from disco/reco generation.
+
+    Returns
+    -------
+    dict
+        Switch-based action dictionary with duplicates removed.
+    """
+    with Timer("Building Action Dictionary (pypowsybl format)"):
+        all_actions_dict = make_raw_all_actions_dict(all_actions)
+
+        result = {}
+        for action_key, action in all_actions_dict.items():
+            switches_flat = {}
+            for vl_id, switches in action._switches_by_voltage_level.items():
+                switches_flat.update(switches)
+
+            voltage_level = next(iter(action._switches_by_voltage_level))
+
+            result[action_key] = {
+                "description": action._description,
+                "description_unitaire": action._description,
+                "VoltageLevelId": voltage_level,
+                "switches": switches_flat,
+            }
+
+        if add_reco_disco_actions and n_grid is not None:
+            dict_extra = _create_dict_disco_reco_pypowsybl_format(
+                n_grid, filter_voltage_levels=filter_voltage_levels
+            )
+            result |= dict_extra
+
+        result = deduplicate_actions_by_switches(result)
+
+    return result
+
+
 def run_rebuild_actions(n_grid, do_from_scratch, repas_file_path, dict_action_to_filter_on=None,
-                        voltage_filter_threshold=300, output_file_base_name="reduced_model_actions"):
+                        voltage_filter_threshold=300, output_file_base_name="reduced_model_actions",
+                        pypowsybl_format=False):
     """
     Orchestrates the action rebuilding process using the environment's grid.
 
@@ -238,6 +396,10 @@ def run_rebuild_actions(n_grid, do_from_scratch, repas_file_path, dict_action_to
         Voltage threshold for filtering actions (default: 300).
     output_file_base_name : str, optional
         Base name for the output file (default: "reduced_model_actions").
+    pypowsybl_format : bool, optional
+        When True and do_from_scratch is True, builds in pypowsybl format
+        (switch-based, no Grid2Op set_bus content) with duplicate deduplication
+        (default: False).
 
     Returns
     -------
@@ -247,9 +409,10 @@ def run_rebuild_actions(n_grid, do_from_scratch, repas_file_path, dict_action_to
     if dict_action_to_filter_on is None:
         dict_action_to_filter_on = {}
 
+    format_label = "pypowsybl" if pypowsybl_format else "grid2op"
     print(
-        f"Rebuilding action dictionary based on current grid snapshot using REPAS file: {repas_file_path} "
-        f"with voltage threshold < {voltage_filter_threshold}..."
+        f"Rebuilding action dictionary ({format_label} format) based on current grid snapshot "
+        f"using REPAS file: {repas_file_path} with voltage threshold < {voltage_filter_threshold}..."
     )
 
     output_file_path = os.path.join(
@@ -269,7 +432,14 @@ def run_rebuild_actions(n_grid, do_from_scratch, repas_file_path, dict_action_to
 
             # Rebuild dictionary
             if do_from_scratch:
-                new_dict_actions = build_action_dict_for_snapshot_from_scratch(n_grid, all_actions,add_reco_disco_actions=True)
+                if pypowsybl_format:
+                    new_dict_actions = build_action_dict_pypowsybl_format_from_scratch(
+                        n_grid, all_actions, add_reco_disco_actions=True
+                    )
+                else:
+                    new_dict_actions = build_action_dict_for_snapshot_from_scratch(
+                        n_grid, all_actions, add_reco_disco_actions=True
+                    )
             else:
                 new_dict_actions = rebuild_action_dict_for_snapshot(n_grid, all_actions, dict_action_to_filter_on)
 

--- a/expert_op4grid_recommender/utils/conversion_actions_repas.py
+++ b/expert_op4grid_recommender/utils/conversion_actions_repas.py
@@ -253,6 +253,51 @@ class UnionFind:
         return result
 
 
+class _IntUnionFind:
+    """
+    Integer-indexed Union-Find for internal use within NetworkTopologyCache.
+
+    Uses list indexing instead of dict lookups (~3x faster for small VLs).
+    Supports fast cloning via list.copy() to reuse a pre-computed initial state.
+    """
+    __slots__ = ['parent', 'rank']
+
+    def __init__(self, n: int):
+        """Initialize n singletons."""
+        self.parent: List[int] = list(range(n))
+        self.rank: List[int] = [0] * n
+
+    @classmethod
+    def from_state(cls, parent: List[int], rank: List[int]) -> '_IntUnionFind':
+        """Clone a pre-computed state (O(n) list copy, avoids re-running all unions)."""
+        uf: '_IntUnionFind' = cls.__new__(cls)
+        uf.parent = list(parent)
+        uf.rank = list(rank)
+        return uf
+
+    def find(self, x: int) -> int:
+        """Find root with iterative path-halving (no recursion overhead)."""
+        while self.parent[x] != x:
+            self.parent[x] = self.parent[self.parent[x]]
+            x = self.parent[x]
+        return x
+
+    def union(self, x: int, y: int) -> None:
+        """Union by rank."""
+        rx, ry = self.find(x), self.find(y)
+        if rx == ry:
+            return
+        if self.rank[rx] < self.rank[ry]:
+            rx, ry = ry, rx
+        self.parent[ry] = rx
+        if self.rank[rx] == self.rank[ry]:
+            self.rank[rx] += 1
+
+    def roots(self) -> List[int]:
+        """Return the root of every element (applies final path compression)."""
+        return [self.find(i) for i in range(len(self.parent))]
+
+
 # =============================================================================
 # Bus number reindexing utility
 # =============================================================================
@@ -368,9 +413,13 @@ class NetworkTopologyCache:
         
         # Pre-compute per-voltage-level data structures
         self._build_vl_topology_data()
-        
+
         # Pre-compute which elements are disconnected from main network component
         self._build_disconnected_elements()
+
+        # Build fast per-VL lookup tables (must run after both methods above so
+        # that _vl_nodes is final and element groupings are consistent).
+        self._build_fast_lookup_tables()
     
     def _build_vl_topology_data(self):
         """Build per-voltage-level topology structures for fast lookup."""
@@ -444,6 +493,78 @@ class NetworkTopologyCache:
                 if vl1 and vl2 and node1 and node2:
                     self._transformers[branch_id] = (node1, vl1, node2, vl2)
     
+    def _build_fast_lookup_tables(self):
+        """
+        Build per-VL lookup tables that make per-action content computation fast.
+
+        Must be called AFTER both _build_vl_topology_data and _build_disconnected_elements
+        so that _vl_nodes contains the final, complete node sets.
+
+        Creates:
+        - _vl_branches_or / _vl_branches_ex: branch IDs grouped by the VL of each terminal
+        - _vl_loads / _vl_generators / _vl_shunts: element IDs grouped by VL
+        - _vl_node_to_idx / _vl_idx_to_node: stable int ↔ str mappings per VL
+        - _vl_switches_int: per-VL switch list with pre-resolved integer indices
+        - _vl_initial_parent / _vl_initial_rank: pre-computed UF state from base switch config
+        """
+        # --- Element groupings by VL (avoids iterrows over full DataFrames per action) ---
+        self._vl_branches_or: Dict[str, List[str]] = defaultdict(list)
+        self._vl_branches_ex: Dict[str, List[str]] = defaultdict(list)
+        self._vl_loads: Dict[str, List[str]] = defaultdict(list)
+        self._vl_generators: Dict[str, List[str]] = defaultdict(list)
+        self._vl_shunts: Dict[str, List[str]] = defaultdict(list)
+
+        for branch_id in self._branches_df.index:
+            vl1 = self._branch_or_to_vl.get(branch_id)
+            vl2 = self._branch_ex_to_vl.get(branch_id)
+            if vl1:
+                self._vl_branches_or[vl1].append(branch_id)
+            if vl2:
+                self._vl_branches_ex[vl2].append(branch_id)
+
+        for load_id, vl in self._load_to_vl.items():
+            if vl:
+                self._vl_loads[vl].append(load_id)
+
+        for gen_id, vl in self._gen_to_vl.items():
+            if vl:
+                self._vl_generators[vl].append(gen_id)
+
+        for shunt_id, vl in self._shunt_to_vl.items():
+            if vl:
+                self._vl_shunts[vl].append(shunt_id)
+
+        # --- Integer mappings + pre-computed initial UF state per VL ---
+        self._vl_node_to_idx: Dict[str, Dict[str, int]] = {}
+        self._vl_idx_to_node: Dict[str, List[str]] = {}
+        self._vl_switches_int: Dict[str, List[Tuple[str, int, int]]] = {}
+        self._vl_initial_parent: Dict[str, List[int]] = {}
+        self._vl_initial_rank: Dict[str, List[int]] = {}
+
+        for vl_id, nodes in self._vl_nodes.items():
+            node_list = sorted(nodes)  # stable ordering
+            node_to_idx = {n: i for i, n in enumerate(node_list)}
+            self._vl_node_to_idx[vl_id] = node_to_idx
+            self._vl_idx_to_node[vl_id] = node_list
+
+            # Resolve switch node strings to integer indices once
+            switches_int: List[Tuple[str, int, int]] = []
+            for switch_id, node1, node2 in self._vl_switches.get(vl_id, []):
+                idx1 = node_to_idx.get(node1)
+                idx2 = node_to_idx.get(node2)
+                if idx1 is not None and idx2 is not None:
+                    switches_int.append((switch_id, idx1, idx2))
+            self._vl_switches_int[vl_id] = switches_int
+
+            # Run UF once for the base switch configuration
+            n_nodes = len(node_list)
+            uf = _IntUnionFind(n_nodes)
+            for switch_id, idx1, idx2 in switches_int:
+                if not self._vl_switch_states.get(switch_id, True):  # False = closed
+                    uf.union(idx1, idx2)
+            self._vl_initial_parent[vl_id] = list(uf.parent)
+            self._vl_initial_rank[vl_id] = list(uf.rank)
+
     def _build_disconnected_elements(self):
         """
         Identify elements that are disconnected from the main network component.
@@ -524,29 +645,25 @@ class NetworkTopologyCache:
                     self._vl_nodes[vl].add(node)
     
     def compute_bus_assignments(
-        self, 
+        self,
         switch_changes: Dict[str, bool],
         impacted_vl_ids: Set[str]
     ) -> Dict[str, Dict[str, int]]:
         """
         Compute bus assignments after applying switch changes.
-        
-        Uses Union-Find to compute connected components (buses) within each VL.
-        
-        Logic:
-        1. Compute connected components within the VL using Union-Find
-        2. Identify which components have at least 2 nodes (connected to a busbar)
-           Components with only 1 node that isn't connected to anything else are isolated
-        3. Isolated nodes get bus = -1
-        4. Connected nodes get positive bus numbers
-        
+
+        Uses integer-indexed Union-Find with a pre-computed initial state to
+        avoid rebuilding from scratch when all changed switches are being closed
+        (the common reconnection case).  For opening operations the UF is rebuilt
+        from scratch using faster integer arrays.
+
         Parameters
         ----------
         switch_changes : Dict[str, bool]
             Mapping from switch_id to new open state (True=open, False=closed).
         impacted_vl_ids : Set[str]
             Set of voltage level IDs where topology needs to be recomputed.
-            
+
         Returns
         -------
         Dict[str, Dict[str, int]]
@@ -554,50 +671,58 @@ class NetworkTopologyCache:
             Bus number is -1 for isolated nodes.
         """
         result = {}
-        
+
         for vl_id in impacted_vl_ids:
-            nodes = self._vl_nodes.get(vl_id, set())
-            if not nodes:
+            node_to_idx = self._vl_node_to_idx.get(vl_id)
+            if not node_to_idx:
                 result[vl_id] = {}
                 continue
-            
-            # Initialize Union-Find with all nodes in this VL
-            uf = UnionFind(list(nodes))
-            
-            # Process all switches in this VL
-            for switch_id, node1, node2 in self._vl_switches.get(vl_id, []):
-                # Determine effective switch state
-                if switch_id in switch_changes:
-                    is_open = switch_changes[switch_id]
-                else:
-                    is_open = self._vl_switch_states.get(switch_id, True)
-                
-                # If switch is closed, unite the two nodes
-                if not is_open:
-                    uf.union(node1, node2)
-            
-            # Get component mapping
-            raw_component_mapping = uf.get_component_mapping()
-            
-            # Count nodes per component to identify isolated single-node components
-            component_node_count: Dict[int, int] = defaultdict(int)
-            for node, comp in raw_component_mapping.items():
-                component_node_count[comp] += 1
-            
-            # A component is "connected" (has a bus) if it has more than 1 node
-            # This means it's connected to at least one other node via a closed switch
-            # Single-node components are isolated
-            final_mapping = {}
-            for node, component in raw_component_mapping.items():
-                if component_node_count[component] > 1:
-                    # Connected component - assign bus number
-                    final_mapping[node] = component
-                else:
-                    # Single isolated node - mark as disconnected
-                    final_mapping[node] = -1
-            
-            result[vl_id] = final_mapping
-        
+
+            switches_int = self._vl_switches_int.get(vl_id, [])
+            initial_parent = self._vl_initial_parent.get(vl_id)
+            initial_rank = self._vl_initial_rank.get(vl_id)
+
+            # Can we reuse the cached initial state?
+            # Yes iff no changed switch is going from closed→open (UF has no undo).
+            can_use_cache = initial_parent is not None
+            if can_use_cache and switch_changes:
+                for switch_id, _, _ in switches_int:
+                    if switch_id in switch_changes:
+                        was_closed = not self._vl_switch_states.get(switch_id, True)
+                        now_open = switch_changes[switch_id]
+                        if was_closed and now_open:
+                            can_use_cache = False
+                            break
+
+            if can_use_cache:
+                # Start from cached base state; only apply newly closed switches.
+                uf = _IntUnionFind.from_state(initial_parent, initial_rank)
+                for switch_id, idx1, idx2 in switches_int:
+                    if switch_id in switch_changes and not switch_changes[switch_id]:
+                        uf.union(idx1, idx2)
+            else:
+                # Rebuild from scratch (opening a switch breaks the cached state).
+                uf = _IntUnionFind(len(node_to_idx))
+                for switch_id, idx1, idx2 in switches_int:
+                    is_open = switch_changes.get(switch_id,
+                                                 self._vl_switch_states.get(switch_id, True))
+                    if not is_open:
+                        uf.union(idx1, idx2)
+
+            # Determine which components are non-isolated (>1 node connected together).
+            root_list = uf.roots()
+            comp_count: Dict[int, int] = {}
+            for r in root_list:
+                comp_count[r] = comp_count.get(r, 0) + 1
+
+            idx_to_node = self._vl_idx_to_node[vl_id]
+            node_bus: Dict[str, int] = {}
+            for idx, node_id in enumerate(idx_to_node):
+                r = root_list[idx]
+                node_bus[node_id] = r if comp_count[r] > 1 else -1
+
+            result[vl_id] = node_bus
+
         return result
     
     def get_element_bus_assignments(
@@ -607,106 +732,89 @@ class NetworkTopologyCache:
     ) -> dict:
         """
         Convert node-to-bus mappings to element-to-bus mappings.
-        
-        The bus numbers are reindexed to sequential numbers starting at 1,
-        PER VOLTAGE LEVEL, so that if the raw bus numbers are [2, 4, 7], 
-        they become [1, 2, 3] within that voltage level.
-        
-        All element types are reindexed together to ensure consistent bus numbers.
-        
+
+        Bus numbers are reindexed to sequential integers starting at 1 per VL.
+        Uses pre-grouped per-VL element lists built in _build_fast_lookup_tables
+        so the iteration is O(elements_in_impacted_VLs) instead of O(all_elements).
+
         Parameters
         ----------
         node_to_bus : Dict[str, Dict[str, int]]
             Mapping from voltage_level_id to (node_id -> bus_number).
         impacted_vl_ids : Set[str]
             Set of impacted voltage level IDs.
-            
+
         Returns
         -------
         dict
             The set_bus dictionary for Grid2Op format.
         """
-        lines_or_id = {}
-        lines_ex_id = {}
-        loads_id = {}
-        generators_id = {}
-        shunts_id = {}
-        
-        # Build element-to-VL mapping for all elements we'll process
-        element_to_vl = {}
-        
-        # Process branches
-        for branch_id, row in self._branches_df.iterrows():
-            vl1 = row['voltage_level1_id']
-            vl2 = row['voltage_level2_id']
-            
-            if vl1 in impacted_vl_ids:
-                node = self._branch_or_to_node.get(branch_id)
-                # Use suffixed key for VL mapping to distinguish or/ex sides
-                element_to_vl[f"{branch_id}_or"] = vl1
-                if node and vl1 in node_to_bus and node in node_to_bus[vl1]:
-                    lines_or_id[branch_id] = node_to_bus[vl1][node]
-                elif node:
-                    lines_or_id[branch_id] = -1
-            
-            if vl2 in impacted_vl_ids:
-                node = self._branch_ex_to_node.get(branch_id)
-                element_to_vl[f"{branch_id}_ex"] = vl2
-                if node and vl2 in node_to_bus and node in node_to_bus[vl2]:
-                    lines_ex_id[branch_id] = node_to_bus[vl2][node]
-                elif node:
-                    lines_ex_id[branch_id] = -1
-        
-        # Process loads
-        for load_id, vl in self._load_to_vl.items():
-            if vl in impacted_vl_ids:
-                element_to_vl[load_id] = vl
-                node = self._load_to_node.get(load_id)
-                if node and vl in node_to_bus and node in node_to_bus[vl]:
-                    loads_id[load_id] = node_to_bus[vl][node]
-                elif node:
-                    loads_id[load_id] = -1
-        
-        # Process generators
-        for gen_id, vl in self._gen_to_vl.items():
-            if vl in impacted_vl_ids:
-                element_to_vl[gen_id] = vl
-                node = self._gen_to_node.get(gen_id)
-                if node and vl in node_to_bus and node in node_to_bus[vl]:
-                    generators_id[gen_id] = node_to_bus[vl][node]
-                elif node:
-                    generators_id[gen_id] = -1
-        
-        # Process shunts
-        for shunt_id, vl in self._shunt_to_vl.items():
-            if vl in impacted_vl_ids:
-                element_to_vl[shunt_id] = vl
-                node = self._shunt_to_node.get(shunt_id)
-                if node and vl in node_to_bus and node in node_to_bus[vl]:
-                    shunts_id[shunt_id] = node_to_bus[vl][node]
-                elif node:
-                    shunts_id[shunt_id] = -1
-        
-        # Build combined set_bus dict with suffixed keys for lines
-        # This ensures all elements are reindexed together consistently
-        combined_set_bus = {
-            'lines_or_id': {f"{bid}_or": bus for bid, bus in lines_or_id.items()},
-            'lines_ex_id': {f"{bid}_ex": bus for bid, bus in lines_ex_id.items()},
+        lines_or_id: Dict[str, int] = {}
+        lines_ex_id: Dict[str, int] = {}
+        loads_id: Dict[str, int] = {}
+        generators_id: Dict[str, int] = {}
+        shunts_id: Dict[str, int] = {}
+
+        for vl_id in impacted_vl_ids:
+            vl_map = node_to_bus.get(vl_id)
+            if not vl_map:
+                continue
+
+            # Collect all positive raw bus values to build a per-VL reindex map.
+            # All element types share the same reindexing so bus numbers are
+            # consistent across types within a VL.
+            raw_buses: set = set()
+            for branch_id in self._vl_branches_or.get(vl_id, []):
+                bus = vl_map.get(self._branch_or_to_node.get(branch_id))
+                if bus and bus > 0:
+                    raw_buses.add(bus)
+            for branch_id in self._vl_branches_ex.get(vl_id, []):
+                bus = vl_map.get(self._branch_ex_to_node.get(branch_id))
+                if bus and bus > 0:
+                    raw_buses.add(bus)
+            for load_id in self._vl_loads.get(vl_id, []):
+                bus = vl_map.get(self._load_to_node.get(load_id))
+                if bus and bus > 0:
+                    raw_buses.add(bus)
+            for gen_id in self._vl_generators.get(vl_id, []):
+                bus = vl_map.get(self._gen_to_node.get(gen_id))
+                if bus and bus > 0:
+                    raw_buses.add(bus)
+            for shunt_id in self._vl_shunts.get(vl_id, []):
+                bus = vl_map.get(self._shunt_to_node.get(shunt_id))
+                if bus and bus > 0:
+                    raw_buses.add(bus)
+
+            bus_remap: Dict[int, int] = {
+                old: new for new, old in enumerate(sorted(raw_buses), start=1)
+            }
+
+            def _assign(out: Dict[str, int], element_ids: List[str],
+                        node_map: Dict[str, str]) -> None:
+                for eid in element_ids:
+                    node = node_map.get(eid)
+                    if node:
+                        raw = vl_map.get(node)
+                        if raw is not None:
+                            out[eid] = bus_remap.get(raw, raw) if raw > 0 else raw
+                        else:
+                            out[eid] = -1
+
+            _assign(lines_or_id, self._vl_branches_or.get(vl_id, []),
+                    self._branch_or_to_node)
+            _assign(lines_ex_id, self._vl_branches_ex.get(vl_id, []),
+                    self._branch_ex_to_node)
+            _assign(loads_id, self._vl_loads.get(vl_id, []), self._load_to_node)
+            _assign(generators_id, self._vl_generators.get(vl_id, []),
+                    self._gen_to_node)
+            _assign(shunts_id, self._vl_shunts.get(vl_id, []), self._shunt_to_node)
+
+        return {
+            'lines_or_id': lines_or_id,
+            'lines_ex_id': lines_ex_id,
             'loads_id': loads_id,
             'generators_id': generators_id,
-            'shunts_id': shunts_id
-        }
-        
-        # Reindex ALL elements together per voltage level
-        reindexed = _reindex_bus_numbers_per_vl(combined_set_bus, element_to_vl)
-        
-        # Convert back: remove suffixes from line keys
-        return {
-            'lines_or_id': {bid.replace('_or', ''): bus for bid, bus in reindexed.get('lines_or_id', {}).items()},
-            'lines_ex_id': {bid.replace('_ex', ''): bus for bid, bus in reindexed.get('lines_ex_id', {}).items()},
-            'loads_id': reindexed.get('loads_id', {}),
-            'generators_id': reindexed.get('generators_id', {}),
-            'shunts_id': reindexed.get('shunts_id', {})
+            'shunts_id': shunts_id,
         }
 
 

--- a/tests/test_action_rebuilder.py
+++ b/tests/test_action_rebuilder.py
@@ -40,7 +40,10 @@ from expert_op4grid_recommender.utils.action_rebuilder import (
     make_raw_all_actions_dict,
     build_action_dict_for_snapshot_from_scratch,
     rebuild_action_dict_for_snapshot,
-    run_rebuild_actions
+    run_rebuild_actions,
+    deduplicate_actions_by_switches,
+    build_action_dict_pypowsybl_format_from_scratch,
+    _create_dict_disco_reco_pypowsybl_format,
 )
 
 from expert_op4grid_recommender.utils.conversion_actions_repas import (
@@ -1395,6 +1398,330 @@ class TestConversionIntegration:
             # Bus numbers should be sequential starting at 1
             expected = set(range(1, len(all_buses) + 1))
             assert all_buses == expected, f"Bus numbers {all_buses} are not sequential from 1"
+
+
+# =============================================================================
+# Tests for deduplicate_actions_by_switches
+# =============================================================================
+
+class TestDeduplicateActionsBySwitches:
+    """Tests for the deduplicate_actions_by_switches function."""
+
+    def test_no_duplicates_unchanged(self):
+        """All actions with distinct switch fingerprints are kept unchanged."""
+        actions = {
+            "A": {"description": "Action A", "switches": {"SW1": True}},
+            "B": {"description": "Action B", "switches": {"SW1": False}},
+            "C": {"description": "Action C", "switches": {"SW2": True}},
+        }
+        result = deduplicate_actions_by_switches(actions)
+
+        assert set(result.keys()) == {"A", "B", "C"}
+        assert "other_action_ids" not in result["A"]
+        assert "other_action_ids" not in result["B"]
+        assert "other_action_ids" not in result["C"]
+
+    def test_two_identical_actions_first_is_reference(self):
+        """When two actions share the same switches, the first is the reference."""
+        actions = {
+            "A": {"description": "Action A", "switches": {"SW1": True, "SW2": False}},
+            "B": {"description": "Action B", "switches": {"SW1": True, "SW2": False}},
+        }
+        result = deduplicate_actions_by_switches(actions)
+
+        assert "A" in result
+        assert "B" not in result
+        assert result["A"]["other_action_ids"] == ["B"]
+
+    def test_three_identical_actions(self):
+        """Three identical actions: first is reference with two in other_action_ids."""
+        actions = {
+            "A": {"switches": {"SW1": True}},
+            "B": {"switches": {"SW1": True}},
+            "C": {"switches": {"SW1": True}},
+        }
+        result = deduplicate_actions_by_switches(actions)
+
+        assert set(result.keys()) == {"A"}
+        assert sorted(result["A"]["other_action_ids"]) == ["B", "C"]
+
+    def test_actions_without_switches_kept_as_is(self):
+        """Actions without 'switches' field (e.g. disco/reco) are kept unchanged."""
+        actions = {
+            "disco_LINE1": {"description": "Disco", "description_unitaire": "Ouverture"},
+            "reco_LINE1": {"description": "Reco", "description_unitaire": "Fermeture"},
+            "A": {"switches": {"SW1": True}},
+        }
+        result = deduplicate_actions_by_switches(actions)
+
+        assert "disco_LINE1" in result
+        assert "reco_LINE1" in result
+        assert "A" in result
+
+    def test_empty_switches_dict_treated_as_no_switches(self):
+        """Actions with an empty 'switches' dict are treated as no-switch actions."""
+        actions = {
+            "A": {"switches": {}},
+            "B": {"switches": {}},
+        }
+        result = deduplicate_actions_by_switches(actions)
+
+        # Both kept as-is (no fingerprint matching for empty dicts)
+        assert "A" in result
+        assert "B" in result
+        assert "other_action_ids" not in result["A"]
+
+    def test_mixed_duplicate_and_unique(self):
+        """Mix of duplicate groups and unique actions handled correctly."""
+        actions = {
+            "A": {"switches": {"SW1": True}},
+            "B": {"switches": {"SW1": True}},   # duplicate of A
+            "C": {"switches": {"SW2": False}},
+            "D": {"switches": {"SW3": True}},
+            "E": {"switches": {"SW3": True}},   # duplicate of D
+        }
+        result = deduplicate_actions_by_switches(actions)
+
+        assert set(result.keys()) == {"A", "C", "D"}
+        assert result["A"]["other_action_ids"] == ["B"]
+        assert result["D"]["other_action_ids"] == ["E"]
+        assert "other_action_ids" not in result["C"]
+
+    def test_empty_dict(self):
+        """Empty input returns empty output."""
+        result = deduplicate_actions_by_switches({})
+        assert result == {}
+
+    def test_original_action_fields_preserved(self):
+        """Reference action preserves all original fields."""
+        actions = {
+            "A": {
+                "description": "My desc",
+                "description_unitaire": "My desc unitaire",
+                "VoltageLevelId": "VL1",
+                "switches": {"VL1_SW1": True},
+            },
+            "B": {
+                "description": "Other desc",
+                "switches": {"VL1_SW1": True},
+            },
+        }
+        result = deduplicate_actions_by_switches(actions)
+
+        assert result["A"]["description"] == "My desc"
+        assert result["A"]["description_unitaire"] == "My desc unitaire"
+        assert result["A"]["VoltageLevelId"] == "VL1"
+        assert result["A"]["switches"] == {"VL1_SW1": True}
+        assert result["A"]["other_action_ids"] == ["B"]
+
+    def test_switch_order_does_not_matter(self):
+        """Two actions with the same switches in different dict order are duplicates."""
+        actions = {
+            "A": {"switches": {"SW1": True, "SW2": False}},
+            "B": {"switches": {"SW2": False, "SW1": True}},
+        }
+        result = deduplicate_actions_by_switches(actions)
+
+        assert "A" in result
+        assert "B" not in result
+        assert result["A"]["other_action_ids"] == ["B"]
+
+
+# =============================================================================
+# Tests for build_action_dict_pypowsybl_format_from_scratch
+# =============================================================================
+
+class TestBuildActionDictPypowsyblFormatFromScratch:
+    """Tests for build_action_dict_pypowsybl_format_from_scratch."""
+
+    def _make_action(self, action_id, switches_by_vl, description="Test desc"):
+        return MockRepasAction(action_id, switches_by_vl, description)
+
+    def test_single_action_structure(self):
+        """Single action produces correct fields: description, description_unitaire, VoltageLevelId, switches."""
+        actions = [
+            self._make_action("ACT1", {"VLA": {"VLA_SW1 DJ_OC": True}}, "Open SW1")
+        ]
+        result = build_action_dict_pypowsybl_format_from_scratch(None, actions)
+
+        assert "ACT1" in result
+        entry = result["ACT1"]
+        assert entry["description"] == "Open SW1"
+        assert entry["description_unitaire"] == "Open SW1"
+        assert entry["VoltageLevelId"] == "VLA"
+        assert entry["switches"] == {"VLA_SW1 DJ_OC": True}
+        assert "content" not in entry
+
+    def test_no_grid2op_content_field(self):
+        """Entries must NOT contain a 'content' / 'set_bus' field."""
+        actions = [
+            self._make_action("ACT1", {"VLA": {"VLA_COUPL DJ_OC": True}}, "Coupl action")
+        ]
+        result = build_action_dict_pypowsybl_format_from_scratch(None, actions)
+
+        assert "content" not in result["ACT1"]
+
+    def test_multi_vl_action_is_split(self):
+        """Multi-VL action is split into one entry per voltage level."""
+        actions = [
+            self._make_action(
+                "MULTI",
+                {
+                    "VLA": {"VLA_COUPL DJ_OC": True},
+                    "VLB": {"VLB_COUPL DJ_OC": False},
+                },
+                "Multi VL action"
+            )
+        ]
+        result = build_action_dict_pypowsybl_format_from_scratch(None, actions)
+
+        assert "MULTI_VLA" in result
+        assert "MULTI_VLB" in result
+        assert result["MULTI_VLA"]["VoltageLevelId"] == "VLA"
+        assert result["MULTI_VLB"]["VoltageLevelId"] == "VLB"
+
+    def test_switches_flattened_per_vl(self):
+        """Single-VL action with multiple switches: all included in switches dict."""
+        actions = [
+            self._make_action(
+                "ACT2",
+                {"VLA": {"VLA_SW1 DJ_OC": True, "VLA_SW2 DJ_OC": True}},
+                "Two switches"
+            )
+        ]
+        result = build_action_dict_pypowsybl_format_from_scratch(None, actions)
+
+        assert result["ACT2"]["switches"] == {
+            "VLA_SW1 DJ_OC": True,
+            "VLA_SW2 DJ_OC": True,
+        }
+
+    def test_duplicates_deduplicated(self):
+        """Actions with identical switch states are deduplicated."""
+        actions = [
+            self._make_action("ACT1", {"VLA": {"VLA_SW1 DJ_OC": True}}, "Action 1"),
+            self._make_action("ACT2", {"VLA": {"VLA_SW1 DJ_OC": True}}, "Action 2"),
+        ]
+        result = build_action_dict_pypowsybl_format_from_scratch(None, actions)
+
+        assert "ACT1" in result
+        assert "ACT2" not in result
+        assert result["ACT1"]["other_action_ids"] == ["ACT2"]
+
+    def test_unique_actions_no_other_action_ids(self):
+        """Unique actions do not have an 'other_action_ids' field."""
+        actions = [
+            self._make_action("ACT1", {"VLA": {"VLA_SW1 DJ_OC": True}}, "Action 1"),
+            self._make_action("ACT2", {"VLA": {"VLA_SW2 DJ_OC": False}}, "Action 2"),
+        ]
+        result = build_action_dict_pypowsybl_format_from_scratch(None, actions)
+
+        assert "other_action_ids" not in result["ACT1"]
+        assert "other_action_ids" not in result["ACT2"]
+
+    def test_no_disco_reco_when_flag_false(self):
+        """No disco/reco entries added when add_reco_disco_actions=False."""
+        actions = [self._make_action("ACT1", {"VLA": {"VLA_SW1 DJ_OC": True}})]
+        result = build_action_dict_pypowsybl_format_from_scratch(None, actions, add_reco_disco_actions=False)
+
+        assert not any(k.startswith("disco_") or k.startswith("reco_") for k in result)
+
+    def test_disco_reco_added_when_flag_true(self):
+        """disco/reco entries are added when add_reco_disco_actions=True and n_grid provided."""
+        actions = [self._make_action("ACT1", {"VLA": {"VLA_SW1 DJ_OC": True}})]
+
+        # Build a minimal mock network for disco/reco
+        mock_net = MagicMock()
+        branches_df = pd.DataFrame(
+            {"voltage_level1_id": ["VL63"], "voltage_level2_id": ["VL63"]},
+            index=["LINE_63kV"]
+        )
+        vl_df = pd.DataFrame({"nominal_v": [63.0]}, index=["VL63"])
+        mock_net.get_branches.return_value = branches_df
+        mock_net.get_voltage_levels.return_value = vl_df
+
+        result = build_action_dict_pypowsybl_format_from_scratch(
+            mock_net, actions, add_reco_disco_actions=True
+        )
+
+        assert "disco_LINE_63kV" in result
+        assert "reco_LINE_63kV" in result
+
+    def test_empty_actions_list(self):
+        """Empty action list produces empty result."""
+        result = build_action_dict_pypowsybl_format_from_scratch(None, [])
+        assert result == {}
+
+
+# =============================================================================
+# Tests for _create_dict_disco_reco_pypowsybl_format
+# =============================================================================
+
+class TestCreateDictDiscoRecoPypowsyblFormat:
+    """Tests for _create_dict_disco_reco_pypowsybl_format."""
+
+    def _make_mock_net(self, lines_vl):
+        """Create a minimal mock network with given line -> (vl1, vl2, nominal_v1, nominal_v2) tuples."""
+        mock_net = MagicMock()
+        idx = list(lines_vl.keys())
+        vl1_ids = [v[0] for v in lines_vl.values()]
+        vl2_ids = [v[1] for v in lines_vl.values()]
+        branches_df = pd.DataFrame(
+            {"voltage_level1_id": vl1_ids, "voltage_level2_id": vl2_ids},
+            index=idx
+        )
+
+        # Build voltage levels DataFrame
+        vl_ids = set(vl1_ids + vl2_ids)
+        vl_rows = {}
+        for key, (vl1, vl2, nv1, nv2) in lines_vl.items():
+            vl_rows[vl1] = nv1
+            vl_rows[vl2] = nv2
+        vl_df = pd.DataFrame({"nominal_v": list(vl_rows.values())}, index=list(vl_rows.keys()))
+
+        mock_net.get_branches.return_value = branches_df
+        mock_net.get_voltage_levels.return_value = vl_df
+        return mock_net
+
+    def test_eligible_line_creates_disco_and_reco(self):
+        """Lines not at filtered voltage levels get disco and reco entries."""
+        net = self._make_mock_net({"LINE_63": ("VL63A", "VL63B", 63., 63.)})
+        result = _create_dict_disco_reco_pypowsybl_format(net)
+
+        assert "disco_LINE_63" in result
+        assert "reco_LINE_63" in result
+
+    def test_filtered_line_excluded(self):
+        """Lines at a filtered voltage level (e.g. 400kV) are excluded."""
+        net = self._make_mock_net({"LINE_400": ("VL400A", "VL400B", 400., 400.)})
+        result = _create_dict_disco_reco_pypowsybl_format(net)
+
+        assert "disco_LINE_400" not in result
+        assert "reco_LINE_400" not in result
+
+    def test_disco_entry_structure(self):
+        """Disco entry has description and description_unitaire, no content."""
+        net = self._make_mock_net({"LINEX": ("VLA", "VLB", 63., 63.)})
+        result = _create_dict_disco_reco_pypowsybl_format(net)
+
+        entry = result["disco_LINEX"]
+        assert "description" in entry
+        assert "description_unitaire" in entry
+        assert "content" not in entry
+        assert "LINEX" in entry["description"]
+        assert "LINEX" in entry["description_unitaire"]
+
+    def test_custom_filter_voltage_levels(self):
+        """Custom filter_voltage_levels are respected."""
+        net = self._make_mock_net({
+            "LINE_63": ("VL63A", "VL63B", 63., 63.),
+            "LINE_90": ("VL90A", "VL90B", 90., 90.),
+        })
+        # Exclude 63kV as well
+        result = _create_dict_disco_reco_pypowsybl_format(net, filter_voltage_levels=[400, 63.])
+
+        assert "disco_LINE_63" not in result
+        assert "disco_LINE_90" in result
 
 
 if __name__ == "__main__":

--- a/tests/test_action_rebuilder.py
+++ b/tests/test_action_rebuilder.py
@@ -1547,7 +1547,8 @@ class TestBuildActionDictPypowsyblFormatFromScratch:
         assert "ACT1" in result
         entry = result["ACT1"]
         assert entry["description"] == "Open SW1"
-        assert entry["description_unitaire"] == "Open SW1"
+        # description_unitaire is the per-VL switch summary, not the full REPAS description
+        assert entry["description_unitaire"] == "Ouverture VLA_SW1 DJ_OC dans le poste VLA"
         assert entry["VoltageLevelId"] == "VLA"
         assert entry["switches"] == {"VLA_SW1 DJ_OC": True}
         assert "content" not in entry


### PR DESCRIPTION
## Summary

This PR extends the `--rebuild-actions` CLI option with pypowsybl-native output and fixes several performance and correctness issues in the pypowsybl backend.

### New feature: `--pypowsybl-format` flag for `--rebuild-actions`

- Adds `--pypowsybl-format` CLI flag: when combined with `--rebuild-actions`, the rebuilt action dictionary is saved in switch-based format (no pre-computed `content.set_bus`), suitable for use with the pypowsybl backend and lazy content computation.
- Fixes `description_unitaire` in rebuilt actions to use a concise per-VL switch summary (`"Ouverture X dans le poste Y"`) instead of the full raw REPAS description.
- Fixes JSON serialisation: uses `ensure_ascii=False` so French accented characters (e.g. `"préventives"`) are written as-is instead of being escaped as `\uXXXX`.

### Performance: lazy content computation without triggering full topology resolution

When using the pypowsybl backend, `content.set_bus` is computed lazily via `LazyActionDict`. The `ActionClassifier` was previously triggering this lazy computation for every action during categorisation (to determine `has_line` / `has_load`), including COUPL/TRO. actions that don't need it.

- `ActionClassifier.__init__` now accepts optional `branch_names` and `load_names` sets (stored as `frozenset` for O(1) lookup).
- New `_infer_has_line_load()` helper: for pypowsybl-format actions (those with a `switches` field), extracts the `AssetName` from each switch ID using the naming convention `{VoltageLevel}_{AssetName} {SuffixXX}_OC` and checks it against the pre-built frozensets — **no lazy loading triggered**.
- `identify_action_type()` now checks COUPL/TRO. first and only calls `_infer_has_line_load()` inside the `Ouverture`/`Fermeture` branches.
- `main.py` builds `branch_names` and `load_names` from `n_grid` once at startup and passes them to the classifier when using the pypowsybl backend.

### Performance: `NetworkTopologyCache` — eliminate O(all_elements) cost per action

`LazyActionDict._compute_content()` calls `NetworkTopologyCache.compute_bus_assignments()` + `get_element_bus_assignments()`. On large grids, `get_element_bus_assignments()` was calling `self._branches_df.iterrows()` (and equivalents for loads/generators/shunts) for **every action**, making node-splitting discovery 6× slower.

**New `_build_fast_lookup_tables()` method** (runs once at cache construction, after `_build_vl_topology_data` and `_build_disconnected_elements`):
- Pre-groups elements by voltage level (`_vl_branches_or/ex`, `_vl_loads`, `_vl_generators`, `_vl_shunts`): eliminates the per-action `iterrows()` over all elements.
- Pre-resolves switch node strings to integer indices (`_vl_switches_int`).
- Pre-computes the initial Union-Find state per VL (`_vl_initial_parent/rank`).

**New `_IntUnionFind`** — integer-array-based Union-Find (~3× faster than the dict-based `UnionFind` for small VLs). Supports `from_state()` to clone a pre-computed parent/rank pair without re-running all switch unions. For reconnection actions (closing open switches), only the delta is applied on the clone.

**Rewritten `get_element_bus_assignments()`** — now iterates only elements in the impacted VL(s) (O(5–20) per action) instead of all elements (O(1000+)). Reindexing is done inline per VL with no separate pass.

## Test plan

- [ ] `pytest tests/test_ActionClassifier.py` — classifier behaviour unchanged for grid2op and pypowsybl paths
- [ ] `pytest tests/test_action_rebuilder.py` — rebuilt action files correct, `--pypowsybl-format` output contains no `\uXXXX` escapes
- [ ] `pytest tests/test_conversion_actions_repas.py` — `UnionFind` tests still pass (API unchanged), `NetworkTopologyCache` produces identical bus assignments before and after optimisation
- [ ] Run full analysis with pypowsybl backend on a large grid and confirm node-splitting discovery is back to ~4 s