### PR TITLE
Add "Action already in target state" filter rule

### DIFF
--- a/expert_op4grid_recommender/action_evaluation/rules.py
+++ b/expert_op4grid_recommender/action_evaluation/rules.py
@@ -81,6 +81,108 @@ class ActionRuleValidator:
         # Cache line_status map for line status checks
         self._line_status_map = {name: status for name, status in zip(obs.name_line, obs.line_status)}
 
+        # Cache current switch states for pypowsybl backend (switch open/close checks)
+        self._current_switch_states = self._build_switch_state_map(obs)
+
+        # Cache line name to index mapping for bus assignment checks
+        self._line_name_to_idx = {name: idx for idx, name in enumerate(obs.name_line)}
+
+    @staticmethod
+    def _build_switch_state_map(obs: Any) -> Optional[Dict[str, bool]]:
+        """
+        Extract current switch states from the observation's network manager (pypowsybl only).
+
+        Returns:
+            Dict mapping switch_id -> is_open (True=open, False=closed), or None if
+            the observation does not expose switch states (e.g., grid2op backend).
+        """
+        try:
+            nm = obs._network_manager
+            switches_df = nm.network.get_switches()
+            return switches_df["open"].to_dict()
+        except (AttributeError, KeyError):
+            return None
+
+    def _is_action_already_in_target_state(self, action_desc: Dict[str, Any], action_type: str) -> bool:
+        """
+        Check whether an action's target state already matches the current grid state.
+
+        For switch-based actions (pypowsybl backend): verifies that every switch in
+        the action is already in its target open/close state.
+
+        For set_bus actions (grid2op backend): verifies that every bus assignment in
+        the action already matches the current observation bus assignments.
+
+        Args:
+            action_desc: The action description dictionary.
+            action_type: The classified action type string.
+
+        Returns:
+            True if the action would be a no-op (already in target state).
+        """
+        # --- Check switch-based actions (pypowsybl) ---
+        switches = action_desc.get("switches")
+        if switches and self._current_switch_states is not None:
+            all_already = True
+            checked_any = False
+            for sid, target_open in switches.items():
+                current_open = self._current_switch_states.get(sid)
+                if current_open is None:
+                    # Try prefix-stripped variant (e.g., PYMONP3_PYMON3COUPL -> PYMON3COUPL)
+                    if '_' in sid:
+                        stripped = sid.split('_', 1)[1]
+                        current_open = self._current_switch_states.get(stripped)
+                if current_open is not None:
+                    checked_any = True
+                    if current_open != target_open:
+                        all_already = False
+                        break
+            if checked_any and all_already:
+                return True
+
+        # --- Check set_bus actions (grid2op / universal) ---
+        content = action_desc.get("content", {})
+        set_bus = content.get("set_bus", {})
+        if not set_bus:
+            return False
+
+        obs = self.obs
+        all_match = True
+        checked_any = False
+
+        # Check lines_or_id bus assignments
+        for line_name, target_bus in set_bus.get("lines_or_id", {}).items():
+            idx = self._line_name_to_idx.get(line_name)
+            if idx is not None:
+                checked_any = True
+                current_bus = int(obs.line_or_bus[idx])
+                if current_bus != target_bus:
+                    all_match = False
+                    break
+
+        # Check lines_ex_id bus assignments
+        if all_match:
+            for line_name, target_bus in set_bus.get("lines_ex_id", {}).items():
+                idx = self._line_name_to_idx.get(line_name)
+                if idx is not None:
+                    checked_any = True
+                    current_bus = int(obs.line_ex_bus[idx])
+                    if current_bus != target_bus:
+                        all_match = False
+                        break
+
+        # Check substations_id topology vectors
+        if all_match and "substations_id" in set_bus:
+            for sub_id, target_topo in set_bus["substations_id"]:
+                if sub_id < len(obs.name_sub):
+                    checked_any = True
+                    current_topo = obs.sub_topology(sub_id)
+                    if not np.array_equal(current_topo, np.array(target_topo)):
+                        all_match = False
+                        break
+
+        return checked_any and all_match
+
     def localize_line_action(self, lines: List[str]) -> str:
         """
         Determines the location category of a line action relative to critical graph paths.
@@ -194,6 +296,11 @@ class ActionRuleValidator:
             localization = self.localize_coupling_action(action_subs)
         else:
             localization = "unknown"
+
+        # Check if action is already in target state (switches or bus assignments)
+        if not do_filter_action:
+            if self._is_action_already_in_target_state(action_desc, action_type):
+                do_filter_action, broken_rule = True, "Action already in target state"
 
         if not do_filter_action:
             do_filter_action, broken_rule_expert = self.check_rules(action_type, localization, subs_topology)

--- a/expert_op4grid_recommender/main.py
+++ b/expert_op4grid_recommender/main.py
@@ -744,6 +744,14 @@ def run_analysis_step2_discovery(context: Dict[str, Any]) -> Dict[str, Any]:
                 else:
                     non_convergence = str(sim_exception)
 
+            # Print summary
+            print(f"{action_id}")
+            if description_unitaire:
+                print(f"  {description_unitaire}")
+            if rho_before is not None and rho_after is not None:
+                print(f"  Rho reduction from {np.round(rho_before, 2)} to {np.round(rho_after, 2)}")
+                print(f"  New max rho is {max_rho:.2f} on line {max_rho_line}")
+
             detailed_actions[action_id] = {
                 "action": action,
                 "description_unitaire": description_unitaire,

--- a/tests/test_ActionRuleValidator.py
+++ b/tests/test_ActionRuleValidator.py
@@ -180,3 +180,186 @@ def test_validator_verify_action_rules_check(): # Removed fixture injection for 
     assert filter_rule is True, f"Expected filter_rule to be True, but got {filter_rule}"
     assert rule_name == "No line disconnection on dispatch path", f"Expected rule 'No line disconnection on dispatch path', but got {rule_name}"
 
+
+## Section 4: "Action already in target state" filter rule tests ##
+
+def test_validator_filter_set_bus_already_in_target_state():
+    """Test that an action whose set_bus matches current bus assignments is filtered."""
+    # All lines on bus 1, action also targets bus 1 → no-op
+    mock_obs = MockObservation(
+        name_sub=["S0", "S1", "S2"],
+        name_line=["L1", "L2", "L3"],
+        line_or_bus=np.array([1, 1, 1]),
+        line_ex_bus=np.array([1, 1, 1]),
+    )
+    mock_paths = ((["L1"], ["S0"]), (["L2"], ["S1"]))
+    validator = ActionRuleValidator(
+        obs=mock_obs,
+        action_space=MockActionSpace(),
+        classifier=ActionClassifier(MockActionSpace()),
+        hubs=["S0"],
+        paths=mock_paths,
+        by_description=True,
+    )
+
+    # Coupling action that targets bus 1 for L1 origin and extremity — already on bus 1
+    action_desc = {
+        "description_unitaire": "Ouverture COUPL S0",
+        "VoltageLevelId": "S0",
+        "content": {"set_bus": {"lines_or_id": {"L1": 1}, "lines_ex_id": {"L1": 1}}},
+    }
+    do_filter, rule = validator.verify_action(action_desc, [])
+    assert do_filter is True
+    assert rule == "Action already in target state"
+
+
+def test_validator_no_filter_set_bus_different_from_current():
+    """Test that an action whose set_bus differs from current state is NOT filtered by this rule."""
+    # L1 currently on bus 1, action targets bus 2 → real change
+    mock_obs = MockObservation(
+        name_sub=["S0", "S1", "S2"],
+        name_line=["L1", "L2", "L3"],
+        line_or_bus=np.array([1, 1, 1]),
+        line_ex_bus=np.array([1, 1, 1]),
+    )
+    mock_paths = ((["L1"], ["S0"]), (["L2"], ["S1"]))
+    validator = ActionRuleValidator(
+        obs=mock_obs,
+        action_space=MockActionSpace(),
+        classifier=ActionClassifier(MockActionSpace()),
+        hubs=["S0"],
+        paths=mock_paths,
+        by_description=True,
+    )
+
+    # Action targets bus 2 for L1 origin — differs from current bus 1
+    action_desc = {
+        "description_unitaire": "Ouverture COUPL S0",
+        "VoltageLevelId": "S0",
+        "content": {"set_bus": {"lines_or_id": {"L1": 2}, "lines_ex_id": {"L1": 1}}},
+    }
+    do_filter, rule = validator.verify_action(action_desc, [])
+    # Should NOT be filtered by the target-state rule (may be filtered by other rules)
+    assert rule != "Action already in target state"
+
+
+def test_validator_filter_switches_already_in_target_state():
+    """Test that a switch-based action is filtered when switches are already in target state."""
+    mock_obs = MockObservation(
+        name_sub=["S0", "S1", "S2"],
+        name_line=["L1", "L2", "L3"],
+    )
+    mock_paths = ((["L1"], ["S0"]), (["L2"], ["S1"]))
+    validator = ActionRuleValidator(
+        obs=mock_obs,
+        action_space=MockActionSpace(),
+        classifier=ActionClassifier(MockActionSpace()),
+        hubs=["S0"],
+        paths=mock_paths,
+        by_description=True,
+    )
+    # Simulate pypowsybl switch states: switch is already open
+    validator._current_switch_states = {
+        "S0_COUPL_OC": True,  # already open
+    }
+
+    action_desc = {
+        "description_unitaire": "Ouverture COUPL S0",
+        "VoltageLevelId": "S0",
+        "content": {"set_bus": {}},
+        "switches": {"S0_COUPL_OC": True},  # target: open (same as current)
+    }
+    do_filter, rule = validator.verify_action(action_desc, [])
+    assert do_filter is True
+    assert rule == "Action already in target state"
+
+
+def test_validator_no_filter_switches_different_from_current():
+    """Test that a switch-based action is NOT filtered when switch state differs."""
+    mock_obs = MockObservation(
+        name_sub=["S0", "S1", "S2"],
+        name_line=["L1", "L2", "L3"],
+    )
+    mock_paths = ((["L1"], ["S0"]), (["L2"], ["S1"]))
+    validator = ActionRuleValidator(
+        obs=mock_obs,
+        action_space=MockActionSpace(),
+        classifier=ActionClassifier(MockActionSpace()),
+        hubs=["S0"],
+        paths=mock_paths,
+        by_description=True,
+    )
+    # Switch is currently closed, action targets open → real change
+    validator._current_switch_states = {
+        "S0_COUPL_OC": False,  # currently closed
+    }
+
+    action_desc = {
+        "description_unitaire": "Ouverture COUPL S0",
+        "VoltageLevelId": "S0",
+        "content": {"set_bus": {}},
+        "switches": {"S0_COUPL_OC": True},  # target: open (differs from current)
+    }
+    do_filter, rule = validator.verify_action(action_desc, [])
+    # Should NOT be filtered by the target-state rule
+    assert rule != "Action already in target state"
+
+
+def test_validator_filter_switches_with_prefix_stripping():
+    """Test that switch ID prefix stripping works for matching."""
+    mock_obs = MockObservation(
+        name_sub=["S0", "S1", "S2"],
+        name_line=["L1", "L2", "L3"],
+    )
+    mock_paths = ((["L1"], ["S0"]), (["L2"], ["S1"]))
+    validator = ActionRuleValidator(
+        obs=mock_obs,
+        action_space=MockActionSpace(),
+        classifier=ActionClassifier(MockActionSpace()),
+        hubs=["S0"],
+        paths=mock_paths,
+        by_description=True,
+    )
+    # Network has switch without prefix; action references it with prefix
+    validator._current_switch_states = {
+        "COUPL_OC": True,  # already open (no prefix)
+    }
+
+    action_desc = {
+        "description_unitaire": "Ouverture COUPL S0",
+        "VoltageLevelId": "S0",
+        "content": {"set_bus": {}},
+        "switches": {"S0_COUPL_OC": True},  # prefix "S0_" stripped → matches "COUPL_OC"
+    }
+    do_filter, rule = validator.verify_action(action_desc, [])
+    assert do_filter is True
+    assert rule == "Action already in target state"
+
+
+def test_validator_filter_substations_id_already_in_target():
+    """Test that a substations_id topology action matching current topo is filtered."""
+    mock_obs = MockObservation(
+        name_sub=["S0", "S1"],
+        name_line=["L1", "L2"],
+        sub_topologies={0: np.array([1, 1, 1]), 1: np.array([1, 1])},
+    )
+    mock_paths = ((["L1"], ["S0"]), (["L2"], ["S1"]))
+    validator = ActionRuleValidator(
+        obs=mock_obs,
+        action_space=MockActionSpace(),
+        classifier=ActionClassifier(MockActionSpace()),
+        hubs=["S0"],
+        paths=mock_paths,
+        by_description=True,
+    )
+
+    # Action targets the same topology already present at S0
+    action_desc = {
+        "description_unitaire": "Fermeture COUPL S0",
+        "VoltageLevelId": "S0",
+        "content": {"set_bus": {"substations_id": [(0, [1, 1, 1])]}},
+    }
+    do_filter, rule = validator.verify_action(action_desc, [np.array([1, 1, 1])])
+    assert do_filter is True
+    assert rule == "Action already in target state"
+


### PR DESCRIPTION
## Summary
This PR adds a new filter rule to detect and exclude actions that would be no-ops because they target a state the grid is already in. This prevents unnecessary action recommendations and improves the quality of the action validator.

## Key Changes

- **New filter rule**: "Action already in target state" detects when an action's target configuration already matches the current grid state
- **Switch-based action support**: For pypowsybl backend, checks if switch open/close states already match the action's target states, with automatic prefix stripping for switch ID matching
- **Bus assignment support**: For grid2op backend, verifies that `set_bus` actions on lines and substations don't change the current topology
- **Caching infrastructure**: Added `_current_switch_states` and `_line_name_to_idx` caches to `ActionRuleValidator` for efficient state lookups
- **Helper method**: Implemented `_is_action_already_in_target_state()` to centralize the no-op detection logic
- **Integration**: The new rule is checked early in the validation pipeline before other rules

## Implementation Details

- The `_build_switch_state_map()` static method safely extracts switch states from pypowsybl's network manager, gracefully falling back to `None` for non-pypowsybl backends
- Switch ID prefix stripping (e.g., "S0_COUPL_OC" → "COUPL_OC") handles cases where action descriptions include voltage level prefixes not present in the network state
- The rule checks three types of topology modifications: `lines_or_id`, `lines_ex_id`, and `substations_id` bus assignments
- Comprehensive test coverage includes positive/negative cases for both switch-based and bus-based actions, plus edge cases like prefix stripping

https://claude.ai/code/session_01E99fjibyDTBsRb9tj8HzfV